### PR TITLE
[tests] - GRouter.sol improve coverage

### DIFF
--- a/.github/workflows/forge_coverage.yml
+++ b/.github/workflows/forge_coverage.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - "contracts/**"
 
 name: coverage
 

--- a/.github/workflows/forge_coverage.yml
+++ b/.github/workflows/forge_coverage.yml
@@ -43,6 +43,7 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/forge_test.yml
+++ b/.github/workflows/forge_test.yml
@@ -3,8 +3,6 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - "contracts/**"
 
 name: foundry-test
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,8 +4,6 @@ on:
         branches:
         - master
     pull_request:
-        paths:
-        - "contracts/**"
 
 jobs:
   lint:

--- a/contracts/GRouter.sol
+++ b/contracts/GRouter.sol
@@ -193,6 +193,7 @@ contract GRouter is IGRouter {
             revert Errors.AmountIsZero();
         }
         ERC20 token = ERC20(routerOracle.getToken(_token_index));
+        // TODO:????? WTF is this
         token.permit(msg.sender, address(this), _amount, deadline, v, r, s);
         amount = depositIntoTrancheForCaller(
             _amount,

--- a/contracts/GRouter.sol
+++ b/contracts/GRouter.sol
@@ -193,7 +193,6 @@ contract GRouter is IGRouter {
             revert Errors.AmountIsZero();
         }
         ERC20 token = ERC20(routerOracle.getToken(_token_index));
-        // TODO:????? WTF is this
         token.permit(msg.sender, address(this), _amount, deadline, v, r, s);
         amount = depositIntoTrancheForCaller(
             _amount,

--- a/test/Base.GSquared.t.sol
+++ b/test/Base.GSquared.t.sol
@@ -31,6 +31,11 @@ contract BaseSetup is Test {
         0xdbb8cf42e1ecb028be3f3dbc922e1d878b963f411dc388ced501601c60f7c6f7;
     bytes32 public DAI_TYPEHASH =
         0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    bytes32 public USDC_DOMAIN_SEPARATOR =
+        0x06c37168a7db5138defc7866392bb87a741f9b3d104deb5094588ce041cae335;
+    bytes32 public USDC_TYPEHASH =
+        0x6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9;
     address public constant THREE_POOL =
         address(0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7);
     ERC20 public constant THREE_POOL_TOKEN =
@@ -360,6 +365,43 @@ contract BaseSetup is Test {
                         nonce,
                         deadline,
                         true // Allowed
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pkey, hash);
+        assertEq(owner, ecrecover(hash, v, r, s));
+        return (v, r, s);
+    }
+
+    /// @notice utils function to sign permit and return k, v and r
+    function signPermitUSDC(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline,
+        uint256 pkey
+    )
+        public
+        returns (
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        )
+    {
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                USDC_DOMAIN_SEPARATOR,
+                keccak256(
+                    abi.encode(
+                        USDC_TYPEHASH,
+                        owner,
+                        spender,
+                        value,
+                        nonce,
+                        deadline
                     )
                 )
             )

--- a/test/Base.GSquared.t.sol
+++ b/test/Base.GSquared.t.sol
@@ -368,4 +368,130 @@ contract BaseSetup is Test {
         assertEq(owner, ecrecover(hash, v, r, s));
         return (v, r, s);
     }
+
+    function runDeposit(
+        address payable[] memory _users,
+        uint256 deposit,
+        uint256 i,
+        uint256 k
+    ) public {
+        bool _break;
+        for (uint256 j; j < i; j++) {
+            address user = _users[j];
+            prepUserCrv(user);
+            vm.startPrank(user);
+            _break = false;
+            for (uint256 l; l < k; l++) {
+                if (deposit > DAI.balanceOf(user)) {
+                    ICurve3Pool(THREE_POOL).add_liquidity(
+                        [DAI.balanceOf(user), 0, 0],
+                        0
+                    );
+                } else {
+                    ICurve3Pool(THREE_POOL).add_liquidity([deposit, 0, 0], 0);
+                }
+                uint256 balance = THREE_POOL_TOKEN.balanceOf(address(user));
+                uint256 shares = gVault.deposit(balance, address(user));
+
+                gTranche.deposit(shares / 2, 0, false, address(user));
+                gTranche.deposit(shares / 2, 0, true, address(user));
+                if (_break) break;
+            }
+            vm.stopPrank();
+        }
+    }
+
+    function _withdraw(
+        bool tranche,
+        uint256 amount,
+        address user
+    ) public returns (uint256 withdrawAmount) {
+        (, withdrawAmount) = gTranche.withdraw(amount, 0, tranche, user);
+    }
+
+    function userWithdrawCheck(
+        address user,
+        uint256 userSeniorAssets,
+        uint256 userJuniorAssets,
+        uint256 k
+    )
+        public
+        returns (uint256 seniorAmountWithdrawn, uint256 juniorAmountWithdrawn)
+    {
+        uint256 SeniorTrancheAssets;
+        uint256 JuniorTrancheAssets;
+
+        for (uint256 l; l < k; l++) {
+            JuniorTrancheAssets = gTranche.trancheBalances(false);
+            vm.startPrank(user);
+            if (l + 1 == k) {
+                seniorAmountWithdrawn += _withdraw(
+                    true,
+                    PWRD.balanceOf(user),
+                    address(user)
+                );
+            } else {
+                seniorAmountWithdrawn += _withdraw(
+                    true,
+                    userSeniorAssets / k,
+                    address(user)
+                );
+            }
+            assertApproxEqAbs(
+                gTranche.trancheBalances(false),
+                JuniorTrancheAssets,
+                1E6
+            );
+
+            SeniorTrancheAssets = gTranche.trancheBalances(true);
+            if (l + 1 == k) {
+                juniorAmountWithdrawn += _withdraw(
+                    false,
+                    GVT.balanceOf(user),
+                    address(user)
+                );
+            } else {
+                juniorAmountWithdrawn += _withdraw(
+                    false,
+                    userJuniorAssets / k,
+                    address(user)
+                );
+            }
+            vm.stopPrank();
+            assertApproxEqAbs(
+                gTranche.trancheBalances(true),
+                SeniorTrancheAssets,
+                1E6
+            );
+        }
+    }
+
+    function runWithdrawal(address user, uint256 k)
+        public
+        returns (uint256 withdrawnSenior, uint256 withdrawnJunior)
+    {
+        uint256 userSeniorAssets = PWRD.balanceOf(user);
+        uint256 userJuniorAssets = GVT.balanceOf(user);
+
+        uint256 initialSeniorTrancheAssets = gTranche.trancheBalances(true);
+        uint256 initialJuniorTrancheAssets = gTranche.trancheBalances(false);
+
+        (withdrawnSenior, withdrawnJunior) = userWithdrawCheck(
+            user,
+            userSeniorAssets,
+            userJuniorAssets,
+            k
+        );
+
+        assertApproxEqAbs(
+            gTranche.trancheBalances(false),
+            delta(initialJuniorTrancheAssets, withdrawnJunior),
+            1E6
+        );
+        assertApproxEqAbs(
+            gTranche.trancheBalances(true),
+            delta(initialSeniorTrancheAssets, withdrawnSenior),
+            1E6
+        );
+    }
 }

--- a/test/GRouter.t.sol
+++ b/test/GRouter.t.sol
@@ -85,4 +85,10 @@ contract RouterTest is Test, BaseSetup {
 
         vm.stopPrank();
     }
+
+    /// @dev Test depositing with zero amount should revert
+    function testDepositZeroAmount() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.AmountIsZero.selector));
+        gRouter.deposit(0, 0, true, 123e18);
+    }
 }

--- a/test/deposit_withdraw.t.sol
+++ b/test/deposit_withdraw.t.sol
@@ -300,7 +300,7 @@ contract TrancheTest is Test, BaseSetup {
         );
     }
 
-    /// @dev Test depositing with approvals by another user
+    /// @dev Test depositing with approvals
     function testDepositWithPermitHappyDAI() public {
         // Make new address and extract private key
         (address addr, uint256 key) = makeAddrAndKey("1337");


### PR DESCRIPTION
## Done:
1. Implement `permit()` eip712 standard helper func for both USDC and DAI to be able to use it in tests
2. Add tests for both `depositWithPermit` and `depositWithAllowedPermit` functions representing USDC and DAI deposits respectively
3. Minor refactorings: moving some helper funcs into base fixture