### PR TITLE
feat: Resolve canHarvest in the context of profits/losses and gas price

### DIFF
--- a/contracts/interfaces/AggregatorV3Interface.sol
+++ b/contracts/interfaces/AggregatorV3Interface.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPLv3
+pragma solidity 0.8.10;
+
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function description() external view returns (string memory);
+
+    function version() external view returns (uint256);
+
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/contracts/strategy/keeper/GStrategyGuard.sol
+++ b/contracts/strategy/keeper/GStrategyGuard.sol
@@ -21,25 +21,6 @@ library GuardErrors {
 
 // gro protocol: https://github.com/groLabs/gro-strategies-brownie
 
-/// Convex rewards interface
-interface IRewards {
-    function balanceOf(address account) external view returns (uint256);
-
-    function earned(address account) external view returns (uint256);
-
-    function withdrawAndUnwrap(uint256 amount, bool claim)
-        external
-        returns (bool);
-
-    function withdrawAllAndUnwrap(bool claim) external;
-
-    function getReward() external returns (bool);
-
-    function extraRewards(uint256 id) external view returns (address);
-
-    function extraRewardsLength() external view returns (uint256);
-}
-
 /// @title Strategy guard
 /// @notice Contract that interacts with strategies, determining when harvest and stop loss should
 ///     be triggered. These actions dont need to be individually strategies specified as the time
@@ -48,9 +29,6 @@ interface IRewards {
 ///     this should not block further execution of other strategies, simplifying the keeper setup
 ///     that will run these jobs.
 contract GStrategyGuard is IGStrategyGuard {
-    int128 internal constant CRV3_INDEX = 1;
-
-
     event LogOwnershipTransferred(
         address indexed previousOwner,
         address indexed newOwner

--- a/lib/forge-std/.github/workflows/sync.yml
+++ b/lib/forge-std/.github/workflows/sync.yml
@@ -1,0 +1,29 @@
+name: Sync Release Branch
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  sync-release-branch:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name, 'v1')
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: v1
+
+      - name: Configure Git
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Sync Release Branch
+        run: |
+          git fetch --tags
+          git checkout v1
+          git reset --hard ${GITHUB_REF}
+          git push --force

--- a/lib/forge-std/foundry.toml
+++ b/lib/forge-std/foundry.toml
@@ -3,7 +3,7 @@ fs_permissions = [{ access = "read-write", path = "./"}]
 
 [rpc_endpoints]
 # The RPC URLs are modified versions of the default for testing initialization.
-mainnet = "https://mainnet.infura.io/v3/16a8be88795540b9b3903d8de0f7baa5" # Different API key.
+mainnet = "https://mainnet.infura.io/v3/b1d3925804e74152b316ca7da97060d3" # Different API key.
 optimism_goerli = "https://goerli.optimism.io/" # Adds a trailing slash.
 arbitrum_one_goerli = "https://goerli-rollup.arbitrum.io/rpc/" # Adds a trailing slash.
 needs_undefined_env_var = "${UNDEFINED_RPC_URL_PLACEHOLDER}"

--- a/lib/forge-std/lib/ds-test/.github/workflows/build.yml
+++ b/lib/forge-std/lib/ds-test/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: "Build"
+on:
+  pull_request:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup dapp binary cache
+        uses: cachix/cachix-action@v12
+        with:
+          name: dapp
+
+      - name: install dapptools
+        run: nix profile install github:dapphub/dapptools#dapp --accept-flake-config
+
+      - name: install foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: test with solc-0.5.17
+        run: dapp --use solc-0.5.17 test -v
+
+      - name: test with solc-0.6.11
+        run: dapp --use solc-0.6.11 test -v
+
+      - name: test with solc-0.7.6
+        run: dapp --use solc-0.7.6 test -v
+
+      - name: test with solc-0.8.18
+        run: dapp --use solc-0.8.18 test -v
+
+      - name: Run tests with foundry
+        run: forge test -vvv
+

--- a/lib/forge-std/lib/ds-test/.gitignore
+++ b/lib/forge-std/lib/ds-test/.gitignore
@@ -1,3 +1,4 @@
 /.dapple
 /build
 /out
+/cache/

--- a/lib/forge-std/lib/ds-test/src/test.sol
+++ b/lib/forge-std/lib/ds-test/src/test.sol
@@ -60,9 +60,9 @@ contract DSTest {
             }
             return globalFailed;
         }
-    } 
+    }
 
-    function fail() internal {
+    function fail() internal virtual {
         if (hasHEVMContext()) {
             (bool status, ) = HEVM_ADDRESS.call(
                 abi.encodePacked(
@@ -107,8 +107,8 @@ contract DSTest {
     function assertEq(address a, address b) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [address]");
-            emit log_named_address("  Expected", b);
-            emit log_named_address("    Actual", a);
+            emit log_named_address("      Left", a);
+            emit log_named_address("     Right", b);
             fail();
         }
     }
@@ -122,8 +122,8 @@ contract DSTest {
     function assertEq(bytes32 a, bytes32 b) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [bytes32]");
-            emit log_named_bytes32("  Expected", b);
-            emit log_named_bytes32("    Actual", a);
+            emit log_named_bytes32("      Left", a);
+            emit log_named_bytes32("     Right", b);
             fail();
         }
     }
@@ -143,8 +143,8 @@ contract DSTest {
     function assertEq(int a, int b) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [int]");
-            emit log_named_int("  Expected", b);
-            emit log_named_int("    Actual", a);
+            emit log_named_int("      Left", a);
+            emit log_named_int("     Right", b);
             fail();
         }
     }
@@ -157,8 +157,8 @@ contract DSTest {
     function assertEq(uint a, uint b) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [uint]");
-            emit log_named_uint("  Expected", b);
-            emit log_named_uint("    Actual", a);
+            emit log_named_uint("      Left", a);
+            emit log_named_uint("     Right", b);
             fail();
         }
     }
@@ -171,8 +171,8 @@ contract DSTest {
     function assertEqDecimal(int a, int b, uint decimals) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [decimal int]");
-            emit log_named_decimal_int("  Expected", b, decimals);
-            emit log_named_decimal_int("    Actual", a, decimals);
+            emit log_named_decimal_int("      Left", a, decimals);
+            emit log_named_decimal_int("     Right", b, decimals);
             fail();
         }
     }
@@ -185,8 +185,8 @@ contract DSTest {
     function assertEqDecimal(uint a, uint b, uint decimals) internal {
         if (a != b) {
             emit log("Error: a == b not satisfied [decimal uint]");
-            emit log_named_decimal_uint("  Expected", b, decimals);
-            emit log_named_decimal_uint("    Actual", a, decimals);
+            emit log_named_decimal_uint("      Left", a, decimals);
+            emit log_named_decimal_uint("     Right", b, decimals);
             fail();
         }
     }
@@ -194,6 +194,99 @@ contract DSTest {
         if (a != b) {
             emit log_named_string("Error", err);
             assertEqDecimal(a, b, decimals);
+        }
+    }
+
+    function assertNotEq(address a, address b) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [address]");
+            emit log_named_address("      Left", a);
+            emit log_named_address("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq(address a, address b, string memory err) internal {
+        if (a == b) {
+            emit log_named_string ("Error", err);
+            assertNotEq(a, b);
+        }
+    }
+
+    function assertNotEq(bytes32 a, bytes32 b) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [bytes32]");
+            emit log_named_bytes32("      Left", a);
+            emit log_named_bytes32("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq(bytes32 a, bytes32 b, string memory err) internal {
+        if (a == b) {
+            emit log_named_string ("Error", err);
+            assertNotEq(a, b);
+        }
+    }
+    function assertNotEq32(bytes32 a, bytes32 b) internal {
+        assertNotEq(a, b);
+    }
+    function assertNotEq32(bytes32 a, bytes32 b, string memory err) internal {
+        assertNotEq(a, b, err);
+    }
+
+    function assertNotEq(int a, int b) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [int]");
+            emit log_named_int("      Left", a);
+            emit log_named_int("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq(int a, int b, string memory err) internal {
+        if (a == b) {
+            emit log_named_string("Error", err);
+            assertNotEq(a, b);
+        }
+    }
+    function assertNotEq(uint a, uint b) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [uint]");
+            emit log_named_uint("      Left", a);
+            emit log_named_uint("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq(uint a, uint b, string memory err) internal {
+        if (a == b) {
+            emit log_named_string("Error", err);
+            assertNotEq(a, b);
+        }
+    }
+    function assertNotEqDecimal(int a, int b, uint decimals) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [decimal int]");
+            emit log_named_decimal_int("      Left", a, decimals);
+            emit log_named_decimal_int("     Right", b, decimals);
+            fail();
+        }
+    }
+    function assertNotEqDecimal(int a, int b, uint decimals, string memory err) internal {
+        if (a == b) {
+            emit log_named_string("Error", err);
+            assertNotEqDecimal(a, b, decimals);
+        }
+    }
+    function assertNotEqDecimal(uint a, uint b, uint decimals) internal {
+        if (a == b) {
+            emit log("Error: a != b not satisfied [decimal uint]");
+            emit log_named_decimal_uint("      Left", a, decimals);
+            emit log_named_decimal_uint("     Right", b, decimals);
+            fail();
+        }
+    }
+    function assertNotEqDecimal(uint a, uint b, uint decimals, string memory err) internal {
+        if (a == b) {
+            emit log_named_string("Error", err);
+            assertNotEqDecimal(a, b, decimals);
         }
     }
 
@@ -421,15 +514,15 @@ contract DSTest {
     function assertLeDecimal(uint a, uint b, uint decimals, string memory err) internal {
         if (a > b) {
             emit log_named_string("Error", err);
-            assertGeDecimal(a, b, decimals);
+            assertLeDecimal(a, b, decimals);
         }
     }
 
     function assertEq(string memory a, string memory b) internal {
         if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
             emit log("Error: a == b not satisfied [string]");
-            emit log_named_string("  Expected", b);
-            emit log_named_string("    Actual", a);
+            emit log_named_string("      Left", a);
+            emit log_named_string("     Right", b);
             fail();
         }
     }
@@ -437,6 +530,21 @@ contract DSTest {
         if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
             emit log_named_string("Error", err);
             assertEq(a, b);
+        }
+    }
+
+    function assertNotEq(string memory a, string memory b) internal {
+        if (keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b))) {
+            emit log("Error: a != b not satisfied [string]");
+            emit log_named_string("      Left", a);
+            emit log_named_string("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq(string memory a, string memory b, string memory err) internal {
+        if (keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b))) {
+            emit log_named_string("Error", err);
+            assertNotEq(a, b);
         }
     }
 
@@ -455,8 +563,8 @@ contract DSTest {
     function assertEq0(bytes memory a, bytes memory b) internal {
         if (!checkEq0(a, b)) {
             emit log("Error: a == b not satisfied [bytes]");
-            emit log_named_bytes("  Expected", b);
-            emit log_named_bytes("    Actual", a);
+            emit log_named_bytes("      Left", a);
+            emit log_named_bytes("     Right", b);
             fail();
         }
     }
@@ -464,6 +572,21 @@ contract DSTest {
         if (!checkEq0(a, b)) {
             emit log_named_string("Error", err);
             assertEq0(a, b);
+        }
+    }
+
+    function assertNotEq0(bytes memory a, bytes memory b) internal {
+        if (checkEq0(a, b)) {
+            emit log("Error: a != b not satisfied [bytes]");
+            emit log_named_bytes("      Left", a);
+            emit log_named_bytes("     Right", b);
+            fail();
+        }
+    }
+    function assertNotEq0(bytes memory a, bytes memory b, string memory err) internal {
+        if (checkEq0(a, b)) {
+            emit log_named_string("Error", err);
+            assertNotEq0(a, b);
         }
     }
 }

--- a/lib/forge-std/lib/ds-test/src/test.t.sol
+++ b/lib/forge-std/lib/ds-test/src/test.t.sol
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.5.0;
+
+import {DSTest} from "./test.sol";
+
+contract DemoTest is DSTest {
+
+    // --- assertTrue ---
+
+    function testAssertTrue() public {
+        assertTrue(true, "msg");
+        assertTrue(true);
+    }
+    function testFailAssertTrue() public {
+        assertTrue(false);
+    }
+    function testFailAssertTrueWithMsg() public {
+        assertTrue(false, "msg");
+    }
+
+    // --- assertEq (Addr) ---
+
+    function testAssertEqAddr() public {
+        assertEq(address(0x0), address(0x0), "msg");
+        assertEq(address(0x0), address(0x0));
+    }
+    function testFailAssertEqAddr() public {
+        assertEq(address(0x0), address(0x1));
+    }
+    function testFailAssertEqAddrWithMsg() public {
+        assertEq(address(0x0), address(0x1), "msg");
+    }
+
+    // --- assertEq (Bytes32) ---
+
+    function testAssertEqBytes32() public {
+        assertEq(bytes32("hi"), bytes32("hi"), "msg");
+        assertEq(bytes32("hi"), bytes32("hi"));
+    }
+    function testFailAssertEqBytes32() public {
+        assertEq(bytes32("hi"), bytes32("ho"));
+    }
+    function testFailAssertEqBytes32WithMsg() public {
+        assertEq(bytes32("hi"), bytes32("ho"), "msg");
+    }
+
+    // --- assertEq (Int) ---
+
+    function testAssertEqInt() public {
+        assertEq(-1, -1, "msg");
+        assertEq(-1, -1);
+    }
+    function testFailAssertEqInt() public {
+        assertEq(-1, -2);
+    }
+    function testFailAssertEqIntWithMsg() public {
+        assertEq(-1, -2, "msg");
+    }
+
+    // --- assertEq (UInt) ---
+
+    function testAssertEqUInt() public {
+        assertEq(uint(1), uint(1), "msg");
+        assertEq(uint(1), uint(1));
+    }
+    function testFailAssertEqUInt() public {
+        assertEq(uint(1), uint(2));
+    }
+    function testFailAssertEqUIntWithMsg() public {
+        assertEq(uint(1), uint(2), "msg");
+    }
+
+    // --- assertEqDecimal (Int) ---
+
+    function testAssertEqDecimalInt() public {
+        assertEqDecimal(-1, -1, 18, "msg");
+        assertEqDecimal(-1, -1, 18);
+    }
+    function testFailAssertEqDecimalInt() public {
+        assertEqDecimal(-1, -2, 18);
+    }
+    function testFailAssertEqDecimalIntWithMsg() public {
+        assertEqDecimal(-1, -2, 18, "msg");
+    }
+
+    // --- assertEqDecimal (UInt) ---
+
+    function testAssertEqDecimalUInt() public {
+        assertEqDecimal(uint(1), uint(1), 18, "msg");
+        assertEqDecimal(uint(1), uint(1), 18);
+    }
+    function testFailAssertEqDecimalUInt() public {
+        assertEqDecimal(uint(1), uint(2), 18);
+    }
+    function testFailAssertEqDecimalUIntWithMsg() public {
+        assertEqDecimal(uint(1), uint(2), 18, "msg");
+    }
+
+    // --- assertNotEq (Addr) ---
+
+    function testAssertNotEqAddr() public {
+        assertNotEq(address(0x0), address(0x1), "msg");
+        assertNotEq(address(0x0), address(0x1));
+    }
+    function testFailAssertNotEqAddr() public {
+        assertNotEq(address(0x0), address(0x0));
+    }
+    function testFailAssertNotEqAddrWithMsg() public {
+        assertNotEq(address(0x0), address(0x0), "msg");
+    }
+
+    // --- assertNotEq (Bytes32) ---
+
+    function testAssertNotEqBytes32() public {
+        assertNotEq(bytes32("hi"), bytes32("ho"), "msg");
+        assertNotEq(bytes32("hi"), bytes32("ho"));
+    }
+    function testFailAssertNotEqBytes32() public {
+        assertNotEq(bytes32("hi"), bytes32("hi"));
+    }
+    function testFailAssertNotEqBytes32WithMsg() public {
+        assertNotEq(bytes32("hi"), bytes32("hi"), "msg");
+    }
+
+    // --- assertNotEq (Int) ---
+
+    function testAssertNotEqInt() public {
+        assertNotEq(-1, -2, "msg");
+        assertNotEq(-1, -2);
+    }
+    function testFailAssertNotEqInt() public {
+        assertNotEq(-1, -1);
+    }
+    function testFailAssertNotEqIntWithMsg() public {
+        assertNotEq(-1, -1, "msg");
+    }
+
+    // --- assertNotEq (UInt) ---
+
+    function testAssertNotEqUInt() public {
+        assertNotEq(uint(1), uint(2), "msg");
+        assertNotEq(uint(1), uint(2));
+    }
+    function testFailAssertNotEqUInt() public {
+        assertNotEq(uint(1), uint(1));
+    }
+    function testFailAssertNotEqUIntWithMsg() public {
+        assertNotEq(uint(1), uint(1), "msg");
+    }
+
+    // --- assertNotEqDecimal (Int) ---
+
+    function testAssertNotEqDecimalInt() public {
+        assertNotEqDecimal(-1, -2, 18, "msg");
+        assertNotEqDecimal(-1, -2, 18);
+    }
+    function testFailAssertNotEqDecimalInt() public {
+        assertNotEqDecimal(-1, -1, 18);
+    }
+    function testFailAssertNotEqDecimalIntWithMsg() public {
+        assertNotEqDecimal(-1, -1, 18, "msg");
+    }
+
+    // --- assertNotEqDecimal (UInt) ---
+
+    function testAssertNotEqDecimalUInt() public {
+        assertNotEqDecimal(uint(1), uint(2), 18, "msg");
+        assertNotEqDecimal(uint(1), uint(2), 18);
+    }
+    function testFailAssertNotEqDecimalUInt() public {
+        assertNotEqDecimal(uint(1), uint(1), 18);
+    }
+    function testFailAssertNotEqDecimalUIntWithMsg() public {
+        assertNotEqDecimal(uint(1), uint(1), 18, "msg");
+    }
+
+    // --- assertGt (UInt) ---
+
+    function testAssertGtUInt() public {
+        assertGt(uint(2), uint(1), "msg");
+        assertGt(uint(3), uint(2));
+    }
+    function testFailAssertGtUInt() public {
+        assertGt(uint(1), uint(2));
+    }
+    function testFailAssertGtUIntWithMsg() public {
+        assertGt(uint(1), uint(2), "msg");
+    }
+
+    // --- assertGt (Int) ---
+
+    function testAssertGtInt() public {
+        assertGt(-1, -2, "msg");
+        assertGt(-1, -3);
+    }
+    function testFailAssertGtInt() public {
+        assertGt(-2, -1);
+    }
+    function testFailAssertGtIntWithMsg() public {
+        assertGt(-2, -1, "msg");
+    }
+
+    // --- assertGtDecimal (UInt) ---
+
+    function testAssertGtDecimalUInt() public {
+        assertGtDecimal(uint(2), uint(1), 18, "msg");
+        assertGtDecimal(uint(3), uint(2), 18);
+    }
+    function testFailAssertGtDecimalUInt() public {
+        assertGtDecimal(uint(1), uint(2), 18);
+    }
+    function testFailAssertGtDecimalUIntWithMsg() public {
+        assertGtDecimal(uint(1), uint(2), 18, "msg");
+    }
+
+    // --- assertGtDecimal (Int) ---
+
+    function testAssertGtDecimalInt() public {
+        assertGtDecimal(-1, -2, 18, "msg");
+        assertGtDecimal(-1, -3, 18);
+    }
+    function testFailAssertGtDecimalInt() public {
+        assertGtDecimal(-2, -1, 18);
+    }
+    function testFailAssertGtDecimalIntWithMsg() public {
+        assertGtDecimal(-2, -1, 18, "msg");
+    }
+
+    // --- assertGe (UInt) ---
+
+    function testAssertGeUInt() public {
+        assertGe(uint(2), uint(1), "msg");
+        assertGe(uint(2), uint(2));
+    }
+    function testFailAssertGeUInt() public {
+        assertGe(uint(1), uint(2));
+    }
+    function testFailAssertGeUIntWithMsg() public {
+        assertGe(uint(1), uint(2), "msg");
+    }
+
+    // --- assertGe (Int) ---
+
+    function testAssertGeInt() public {
+        assertGe(-1, -2, "msg");
+        assertGe(-1, -1);
+    }
+    function testFailAssertGeInt() public {
+        assertGe(-2, -1);
+    }
+    function testFailAssertGeIntWithMsg() public {
+        assertGe(-2, -1, "msg");
+    }
+
+    // --- assertGeDecimal (UInt) ---
+
+    function testAssertGeDecimalUInt() public {
+        assertGeDecimal(uint(2), uint(1), 18, "msg");
+        assertGeDecimal(uint(2), uint(2), 18);
+    }
+    function testFailAssertGeDecimalUInt() public {
+        assertGeDecimal(uint(1), uint(2), 18);
+    }
+    function testFailAssertGeDecimalUIntWithMsg() public {
+        assertGeDecimal(uint(1), uint(2), 18, "msg");
+    }
+
+    // --- assertGeDecimal (Int) ---
+
+    function testAssertGeDecimalInt() public {
+        assertGeDecimal(-1, -2, 18, "msg");
+        assertGeDecimal(-1, -2, 18);
+    }
+    function testFailAssertGeDecimalInt() public {
+        assertGeDecimal(-2, -1, 18);
+    }
+    function testFailAssertGeDecimalIntWithMsg() public {
+        assertGeDecimal(-2, -1, 18, "msg");
+    }
+
+    // --- assertLt (UInt) ---
+
+    function testAssertLtUInt() public {
+        assertLt(uint(1), uint(2), "msg");
+        assertLt(uint(1), uint(3));
+    }
+    function testFailAssertLtUInt() public {
+        assertLt(uint(2), uint(2));
+    }
+    function testFailAssertLtUIntWithMsg() public {
+        assertLt(uint(3), uint(2), "msg");
+    }
+
+    // --- assertLt (Int) ---
+
+    function testAssertLtInt() public {
+        assertLt(-2, -1, "msg");
+        assertLt(-1, 0);
+    }
+    function testFailAssertLtInt() public {
+        assertLt(-1, -2);
+    }
+    function testFailAssertLtIntWithMsg() public {
+        assertLt(-1, -1, "msg");
+    }
+
+    // --- assertLtDecimal (UInt) ---
+
+    function testAssertLtDecimalUInt() public {
+        assertLtDecimal(uint(1), uint(2), 18, "msg");
+        assertLtDecimal(uint(2), uint(3), 18);
+    }
+    function testFailAssertLtDecimalUInt() public {
+        assertLtDecimal(uint(1), uint(1), 18);
+    }
+    function testFailAssertLtDecimalUIntWithMsg() public {
+        assertLtDecimal(uint(2), uint(1), 18, "msg");
+    }
+
+    // --- assertLtDecimal (Int) ---
+
+    function testAssertLtDecimalInt() public {
+        assertLtDecimal(-2, -1, 18, "msg");
+        assertLtDecimal(-2, -1, 18);
+    }
+    function testFailAssertLtDecimalInt() public {
+        assertLtDecimal(-2, -2, 18);
+    }
+    function testFailAssertLtDecimalIntWithMsg() public {
+        assertLtDecimal(-1, -2, 18, "msg");
+    }
+
+    // --- assertLe (UInt) ---
+
+    function testAssertLeUInt() public {
+        assertLe(uint(1), uint(2), "msg");
+        assertLe(uint(1), uint(1));
+    }
+    function testFailAssertLeUInt() public {
+        assertLe(uint(4), uint(2));
+    }
+    function testFailAssertLeUIntWithMsg() public {
+        assertLe(uint(3), uint(2), "msg");
+    }
+
+    // --- assertLe (Int) ---
+
+    function testAssertLeInt() public {
+        assertLe(-2, -1, "msg");
+        assertLe(-1, -1);
+    }
+    function testFailAssertLeInt() public {
+        assertLe(-1, -2);
+    }
+    function testFailAssertLeIntWithMsg() public {
+        assertLe(-1, -3, "msg");
+    }
+
+    // --- assertLeDecimal (UInt) ---
+
+    function testAssertLeDecimalUInt() public {
+        assertLeDecimal(uint(1), uint(2), 18, "msg");
+        assertLeDecimal(uint(2), uint(2), 18);
+    }
+    function testFailAssertLeDecimalUInt() public {
+        assertLeDecimal(uint(1), uint(0), 18);
+    }
+    function testFailAssertLeDecimalUIntWithMsg() public {
+        assertLeDecimal(uint(1), uint(0), 18, "msg");
+    }
+
+    // --- assertLeDecimal (Int) ---
+
+    function testAssertLeDecimalInt() public {
+        assertLeDecimal(-2, -1, 18, "msg");
+        assertLeDecimal(-2, -2, 18);
+    }
+    function testFailAssertLeDecimalInt() public {
+        assertLeDecimal(-2, -3, 18);
+    }
+    function testFailAssertLeDecimalIntWithMsg() public {
+        assertLeDecimal(-1, -2, 18, "msg");
+    }
+
+    // --- assertNotEq (String) ---
+
+    function testAssertNotEqString() public {
+        assertNotEq(new string(1), new string(2), "msg");
+        assertNotEq(new string(1), new string(2));
+    }
+    function testFailAssertNotEqString() public {
+        assertNotEq(new string(1), new string(1));
+    }
+    function testFailAssertNotEqStringWithMsg() public {
+        assertNotEq(new string(1), new string(1), "msg");
+    }
+
+    // --- assertNotEq0 (Bytes) ---
+
+    function testAssertNotEq0Bytes() public {
+        assertNotEq0(bytes("hi"), bytes("ho"), "msg");
+        assertNotEq0(bytes("hi"), bytes("ho"));
+    }
+    function testFailAssertNotEq0Bytes() public {
+        assertNotEq0(bytes("hi"), bytes("hi"));
+    }
+    function testFailAssertNotEq0BytesWithMsg() public {
+        assertNotEq0(bytes("hi"), bytes("hi"), "msg");
+    }
+
+    // --- fail override ---
+
+    // ensure that fail can be overridden
+    function fail() internal override {
+        super.fail();
+    }
+}

--- a/lib/forge-std/package.json
+++ b/lib/forge-std/package.json
@@ -1,13 +1,13 @@
 {
   "name": "forge-std",
-  "version": "1.4.0",
+  "version": "1.5.6",
   "description": "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry.",
   "homepage": "https://book.getfoundry.sh/forge/forge-std",
   "bugs": "https://github.com/foundry-rs/forge-std/issues",
   "license": "(Apache-2.0 OR MIT)",
   "author": "Contributors to Forge Standard Library",
   "files": [
-    "src/*"
+    "src/**/*"
   ],
   "repository": {
     "type": "git",

--- a/lib/forge-std/src/Base.sol
+++ b/lib/forge-std/src/Base.sol
@@ -9,12 +9,17 @@ abstract contract CommonBase {
     address internal constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
     // console.sol and console2.sol work by executing a staticcall to this address.
     address internal constant CONSOLE = 0x000000000000000000636F6e736F6c652e6c6f67;
+    // Used when deploying with create2, https://github.com/Arachnid/deterministic-deployment-proxy.
+    address internal constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
     // Default address for tx.origin and msg.sender, 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38.
     address internal constant DEFAULT_SENDER = address(uint160(uint256(keccak256("foundry default caller"))));
     // Address of the test contract, deployed by the DEFAULT_SENDER.
     address internal constant DEFAULT_TEST_CONTRACT = 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f;
     // Deterministic deployment address of the Multicall3 contract.
     address internal constant MULTICALL3_ADDRESS = 0xcA11bde05977b3631167028862bE2a173976CA11;
+    // The order of the secp256k1 curve.
+    uint256 internal constant SECP256K1_ORDER =
+        115792089237316195423570985008687907852837564279074904382605163141518161494337;
 
     uint256 internal constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
@@ -26,8 +31,5 @@ abstract contract CommonBase {
 abstract contract TestBase is CommonBase {}
 
 abstract contract ScriptBase is CommonBase {
-    // Used when deploying with create2, https://github.com/Arachnid/deterministic-deployment-proxy.
-    address internal constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
-
     VmSafe internal constant vmSafe = VmSafe(VM_ADDRESS);
 }

--- a/lib/forge-std/src/StdAssertions.sol
+++ b/lib/forge-std/src/StdAssertions.sol
@@ -28,8 +28,8 @@ abstract contract StdAssertions is DSTest {
     function assertEq(bool a, bool b) internal virtual {
         if (a != b) {
             emit log("Error: a == b not satisfied [bool]");
-            emit log_named_string("  Expected", b ? "true" : "false");
-            emit log_named_string("    Actual", a ? "true" : "false");
+            emit log_named_string("      Left", a ? "true" : "false");
+            emit log_named_string("     Right", b ? "true" : "false");
             fail();
         }
     }
@@ -52,8 +52,8 @@ abstract contract StdAssertions is DSTest {
     function assertEq(uint256[] memory a, uint256[] memory b) internal virtual {
         if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
             emit log("Error: a == b not satisfied [uint[]]");
-            emit log_named_array("  Expected", b);
-            emit log_named_array("    Actual", a);
+            emit log_named_array("      Left", a);
+            emit log_named_array("     Right", b);
             fail();
         }
     }
@@ -61,8 +61,8 @@ abstract contract StdAssertions is DSTest {
     function assertEq(int256[] memory a, int256[] memory b) internal virtual {
         if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
             emit log("Error: a == b not satisfied [int[]]");
-            emit log_named_array("  Expected", b);
-            emit log_named_array("    Actual", a);
+            emit log_named_array("      Left", a);
+            emit log_named_array("     Right", b);
             fail();
         }
     }
@@ -70,8 +70,8 @@ abstract contract StdAssertions is DSTest {
     function assertEq(address[] memory a, address[] memory b) internal virtual {
         if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
             emit log("Error: a == b not satisfied [address[]]");
-            emit log_named_array("  Expected", b);
-            emit log_named_array("    Actual", a);
+            emit log_named_array("      Left", a);
+            emit log_named_array("     Right", b);
             fail();
         }
     }
@@ -107,8 +107,8 @@ abstract contract StdAssertions is DSTest {
 
         if (delta > maxDelta) {
             emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("  Expected", b);
-            emit log_named_uint("    Actual", a);
+            emit log_named_uint("      Left", a);
+            emit log_named_uint("     Right", b);
             emit log_named_uint(" Max Delta", maxDelta);
             emit log_named_uint("     Delta", delta);
             fail();
@@ -129,8 +129,8 @@ abstract contract StdAssertions is DSTest {
 
         if (delta > maxDelta) {
             emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_decimal_uint("  Expected", b, decimals);
-            emit log_named_decimal_uint("    Actual", a, decimals);
+            emit log_named_decimal_uint("      Left", a, decimals);
+            emit log_named_decimal_uint("     Right", b, decimals);
             emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
             emit log_named_decimal_uint("     Delta", delta, decimals);
             fail();
@@ -154,8 +154,8 @@ abstract contract StdAssertions is DSTest {
 
         if (delta > maxDelta) {
             emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_int("  Expected", b);
-            emit log_named_int("    Actual", a);
+            emit log_named_int("       Left", a);
+            emit log_named_int("      Right", b);
             emit log_named_uint(" Max Delta", maxDelta);
             emit log_named_uint("     Delta", delta);
             fail();
@@ -176,8 +176,8 @@ abstract contract StdAssertions is DSTest {
 
         if (delta > maxDelta) {
             emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_decimal_int("  Expected", b, decimals);
-            emit log_named_decimal_int("    Actual", a, decimals);
+            emit log_named_decimal_int("      Left", a, decimals);
+            emit log_named_decimal_int("     Right", b, decimals);
             emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
             emit log_named_decimal_uint("     Delta", delta, decimals);
             fail();
@@ -201,16 +201,16 @@ abstract contract StdAssertions is DSTest {
         uint256 b,
         uint256 maxPercentDelta // An 18 decimal fixed point number, where 1e18 == 100%
     ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("    Expected", b);
-            emit log_named_uint("      Actual", a);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            emit log_named_uint("        Left", a);
+            emit log_named_uint("       Right", b);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
             fail();
         }
     }
@@ -221,7 +221,7 @@ abstract contract StdAssertions is DSTest {
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         string memory err
     ) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
@@ -237,16 +237,16 @@ abstract contract StdAssertions is DSTest {
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         uint256 decimals
     ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_decimal_uint("    Expected", b, decimals);
-            emit log_named_decimal_uint("      Actual", a, decimals);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            emit log_named_decimal_uint("        Left", a, decimals);
+            emit log_named_decimal_uint("       Right", b, decimals);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
             fail();
         }
     }
@@ -258,7 +258,7 @@ abstract contract StdAssertions is DSTest {
         uint256 decimals,
         string memory err
     ) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
@@ -269,22 +269,22 @@ abstract contract StdAssertions is DSTest {
     }
 
     function assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_int("    Expected", b);
-            emit log_named_int("      Actual", a);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            emit log_named_int("        Left", a);
+            emit log_named_int("       Right", b);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
             fail();
         }
     }
 
     function assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta, string memory err) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
@@ -295,16 +295,16 @@ abstract contract StdAssertions is DSTest {
     }
 
     function assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_decimal_int("    Expected", b, decimals);
-            emit log_named_decimal_int("      Actual", a, decimals);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            emit log_named_decimal_int("        Left", a, decimals);
+            emit log_named_decimal_int("       Right", b, decimals);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
             fail();
         }
     }
@@ -313,13 +313,64 @@ abstract contract StdAssertions is DSTest {
         internal
         virtual
     {
-        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log_named_string("Error", err);
             assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
+        }
+    }
+
+    function assertEqCall(address target, bytes memory callDataA, bytes memory callDataB) internal virtual {
+        assertEqCall(target, callDataA, target, callDataB, true);
+    }
+
+    function assertEqCall(address targetA, bytes memory callDataA, address targetB, bytes memory callDataB)
+        internal
+        virtual
+    {
+        assertEqCall(targetA, callDataA, targetB, callDataB, true);
+    }
+
+    function assertEqCall(address target, bytes memory callDataA, bytes memory callDataB, bool strictRevertData)
+        internal
+        virtual
+    {
+        assertEqCall(target, callDataA, target, callDataB, strictRevertData);
+    }
+
+    function assertEqCall(
+        address targetA,
+        bytes memory callDataA,
+        address targetB,
+        bytes memory callDataB,
+        bool strictRevertData
+    ) internal virtual {
+        (bool successA, bytes memory returnDataA) = address(targetA).call(callDataA);
+        (bool successB, bytes memory returnDataB) = address(targetB).call(callDataB);
+
+        if (successA && successB) {
+            assertEq(returnDataA, returnDataB, "Call return data does not match");
+        }
+
+        if (!successA && !successB && strictRevertData) {
+            assertEq(returnDataA, returnDataB, "Call revert data does not match");
+        }
+
+        if (!successA && successB) {
+            emit log("Error: Calls were not equal");
+            emit log_named_bytes("  Left call revert data", returnDataA);
+            emit log_named_bytes(" Right call return data", returnDataB);
+            fail();
+        }
+
+        if (successA && !successB) {
+            emit log("Error: Calls were not equal");
+            emit log_named_bytes("  Left call return data", returnDataA);
+            emit log_named_bytes(" Right call revert data", returnDataB);
+            fail();
         }
     }
 }

--- a/lib/forge-std/src/StdCheats.sol
+++ b/lib/forge-std/src/StdCheats.sol
@@ -5,6 +5,7 @@ pragma experimental ABIEncoderV2;
 
 import {StdStorage, stdStorage} from "./StdStorage.sol";
 import {Vm} from "./Vm.sol";
+import {console2} from "./console2.sol";
 
 abstract contract StdCheatsSafe {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
@@ -186,6 +187,32 @@ abstract contract StdCheatsSafe {
     struct TxReturn {
         string internalType;
         string value;
+    }
+
+    struct Account {
+        address addr;
+        uint256 key;
+    }
+
+    // Checks that `addr` is not blacklisted by token contracts that have a blacklist.
+    function assumeNoBlacklisted(address token, address addr) internal virtual {
+        // Nothing to check if `token` is not a contract.
+        uint256 tokenCodeSize;
+        assembly {
+            tokenCodeSize := extcodesize(token)
+        }
+        require(tokenCodeSize > 0, "StdCheats assumeNoBlacklisted(address,address): Token address is not a contract.");
+
+        bool success;
+        bytes memory returnData;
+
+        // 4-byte selector for `isBlacklisted(address)`, used by USDC.
+        (success, returnData) = token.staticcall(abi.encodeWithSelector(0xfe575a87, addr));
+        vm.assume(!success || abi.decode(returnData, (bool)) == false);
+
+        // 4-byte selector for `isBlackListed(address)`, used by USDT.
+        (success, returnData) = token.staticcall(abi.encodeWithSelector(0xe47d6060, addr));
+        vm.assume(!success || abi.decode(returnData, (bool)) == false);
     }
 
     function assumeNoPrecompiles(address addr) internal virtual {
@@ -411,6 +438,25 @@ abstract contract StdCheatsSafe {
         (addr,) = makeAddrAndKey(name);
     }
 
+    // Destroys an account immediately, sending the balance to beneficiary.
+    // Destroying means: balance will be zero, code will be empty, and nonce will be 0
+    // This is similar to selfdestruct but not identical: selfdestruct destroys code and nonce
+    // only after tx ends, this will run immediately.
+    function destroyAccount(address who, address beneficiary) internal virtual {
+        uint256 currBalance = who.balance;
+        vm.etch(who, abi.encode());
+        vm.deal(who, 0);
+        vm.resetNonce(who);
+
+        uint256 beneficiaryBalance = beneficiary.balance;
+        vm.deal(beneficiary, currBalance + beneficiaryBalance);
+    }
+
+    // creates a struct containing both a labeled address and the corresponding private key
+    function makeAccount(string memory name) internal virtual returns (Account memory account) {
+        (account.addr, account.key) = makeAddrAndKey(name);
+    }
+
     function deriveRememberKey(string memory mnemonic, uint32 index)
         internal
         virtual
@@ -537,6 +583,11 @@ abstract contract StdCheats is StdCheatsSafe {
         vm.startPrank(msgSender);
     }
 
+    function changePrank(address msgSender, address txOrigin) internal virtual {
+        vm.stopPrank();
+        vm.startPrank(msgSender, txOrigin);
+    }
+
     // The same as Vm's `deal`
     // Use the alternative signature for ERC20 tokens
     function deal(address to, uint256 give) internal virtual {
@@ -549,9 +600,15 @@ abstract contract StdCheats is StdCheatsSafe {
         deal(token, to, give, false);
     }
 
+    // Set the balance of an account for any ERC1155 token
+    // Use the alternative signature to update `totalSupply`
+    function dealERC1155(address token, address to, uint256 id, uint256 give) internal virtual {
+        dealERC1155(token, to, id, give, false);
+    }
+
     function deal(address token, address to, uint256 give, bool adjust) internal virtual {
         // get current balance
-        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        (, bytes memory balData) = token.staticcall(abi.encodeWithSelector(0x70a08231, to));
         uint256 prevBal = abi.decode(balData, (uint256));
 
         // update balance
@@ -559,7 +616,7 @@ abstract contract StdCheats is StdCheatsSafe {
 
         // update total supply
         if (adjust) {
-            (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0x18160ddd));
+            (, bytes memory totSupData) = token.staticcall(abi.encodeWithSelector(0x18160ddd));
             uint256 totSup = abi.decode(totSupData, (uint256));
             if (give < prevBal) {
                 totSup -= (prevBal - give);
@@ -568,5 +625,52 @@ abstract contract StdCheats is StdCheatsSafe {
             }
             stdstore.target(token).sig(0x18160ddd).checked_write(totSup);
         }
+    }
+
+    function dealERC1155(address token, address to, uint256 id, uint256 give, bool adjust) internal virtual {
+        // get current balance
+        (, bytes memory balData) = token.staticcall(abi.encodeWithSelector(0x00fdd58e, to, id));
+        uint256 prevBal = abi.decode(balData, (uint256));
+
+        // update balance
+        stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
+
+        // update total supply
+        if (adjust) {
+            (, bytes memory totSupData) = token.staticcall(abi.encodeWithSelector(0xbd85b039, id));
+            require(
+                totSupData.length != 0,
+                "StdCheats deal(address,address,uint,uint,bool): target contract is not ERC1155Supply."
+            );
+            uint256 totSup = abi.decode(totSupData, (uint256));
+            if (give < prevBal) {
+                totSup -= (prevBal - give);
+            } else {
+                totSup += (give - prevBal);
+            }
+            stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup);
+        }
+    }
+
+    function dealERC721(address token, address to, uint256 id) internal virtual {
+        // check if token id is already minted and the actual owner.
+        (bool successMinted, bytes memory ownerData) = token.staticcall(abi.encodeWithSelector(0x6352211e, id));
+        require(successMinted, "StdCheats deal(address,address,uint,bool): id not minted.");
+
+        // get owner current balance
+        (, bytes memory fromBalData) =
+            token.staticcall(abi.encodeWithSelector(0x70a08231, abi.decode(ownerData, (address))));
+        uint256 fromPrevBal = abi.decode(fromBalData, (uint256));
+
+        // get new user current balance
+        (, bytes memory toBalData) = token.staticcall(abi.encodeWithSelector(0x70a08231, to));
+        uint256 toPrevBal = abi.decode(toBalData, (uint256));
+
+        // update balances
+        stdstore.target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
+        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
+
+        // update owner
+        stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
     }
 }

--- a/lib/forge-std/src/StdStyle.sol
+++ b/lib/forge-std/src/StdStyle.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+import {Vm} from "./Vm.sol";
+
+library StdStyle {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    string constant RED = "\u001b[91m";
+    string constant GREEN = "\u001b[92m";
+    string constant YELLOW = "\u001b[93m";
+    string constant BLUE = "\u001b[94m";
+    string constant MAGENTA = "\u001b[95m";
+    string constant CYAN = "\u001b[96m";
+    string constant BOLD = "\u001b[1m";
+    string constant DIM = "\u001b[2m";
+    string constant ITALIC = "\u001b[3m";
+    string constant UNDERLINE = "\u001b[4m";
+    string constant INVERSE = "\u001b[7m";
+    string constant RESET = "\u001b[0m";
+
+    function styleConcat(string memory style, string memory self) private pure returns (string memory) {
+        return string(abi.encodePacked(style, self, RESET));
+    }
+
+    function red(string memory self) internal pure returns (string memory) {
+        return styleConcat(RED, self);
+    }
+
+    function red(uint256 self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function red(int256 self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function red(address self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function red(bool self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function redBytes(bytes memory self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function redBytes32(bytes32 self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function green(string memory self) internal pure returns (string memory) {
+        return styleConcat(GREEN, self);
+    }
+
+    function green(uint256 self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function green(int256 self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function green(address self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function green(bool self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function greenBytes(bytes memory self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function greenBytes32(bytes32 self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function yellow(string memory self) internal pure returns (string memory) {
+        return styleConcat(YELLOW, self);
+    }
+
+    function yellow(uint256 self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellow(int256 self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellow(address self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellow(bool self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellowBytes(bytes memory self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellowBytes32(bytes32 self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function blue(string memory self) internal pure returns (string memory) {
+        return styleConcat(BLUE, self);
+    }
+
+    function blue(uint256 self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blue(int256 self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blue(address self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blue(bool self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blueBytes(bytes memory self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blueBytes32(bytes32 self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function magenta(string memory self) internal pure returns (string memory) {
+        return styleConcat(MAGENTA, self);
+    }
+
+    function magenta(uint256 self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magenta(int256 self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magenta(address self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magenta(bool self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magentaBytes(bytes memory self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magentaBytes32(bytes32 self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function cyan(string memory self) internal pure returns (string memory) {
+        return styleConcat(CYAN, self);
+    }
+
+    function cyan(uint256 self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyan(int256 self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyan(address self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyan(bool self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyanBytes(bytes memory self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyanBytes32(bytes32 self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function bold(string memory self) internal pure returns (string memory) {
+        return styleConcat(BOLD, self);
+    }
+
+    function bold(uint256 self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function bold(int256 self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function bold(address self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function bold(bool self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function boldBytes(bytes memory self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function boldBytes32(bytes32 self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function dim(string memory self) internal pure returns (string memory) {
+        return styleConcat(DIM, self);
+    }
+
+    function dim(uint256 self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dim(int256 self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dim(address self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dim(bool self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dimBytes(bytes memory self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dimBytes32(bytes32 self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function italic(string memory self) internal pure returns (string memory) {
+        return styleConcat(ITALIC, self);
+    }
+
+    function italic(uint256 self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italic(int256 self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italic(address self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italic(bool self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italicBytes(bytes memory self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italicBytes32(bytes32 self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function underline(string memory self) internal pure returns (string memory) {
+        return styleConcat(UNDERLINE, self);
+    }
+
+    function underline(uint256 self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underline(int256 self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underline(address self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underline(bool self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underlineBytes(bytes memory self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underlineBytes32(bytes32 self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function inverse(string memory self) internal pure returns (string memory) {
+        return styleConcat(INVERSE, self);
+    }
+
+    function inverse(uint256 self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverse(int256 self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverse(address self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverse(bool self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverseBytes(bytes memory self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverseBytes32(bytes32 self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+}

--- a/lib/forge-std/src/StdUtils.sol
+++ b/lib/forge-std/src/StdUtils.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import {IMulticall3} from "./interfaces/IMulticall3.sol";
-// TODO Remove import.
 import {VmSafe} from "./Vm.sol";
 
 abstract contract StdUtils {
@@ -17,6 +16,8 @@ abstract contract StdUtils {
     address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
     uint256 private constant INT256_MIN_ABS =
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    uint256 private constant SECP256K1_ORDER =
+        115792089237316195423570985008687907852837564279074904382605163141518161494337;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
@@ -35,7 +36,7 @@ abstract contract StdUtils {
 
         uint256 size = max - min + 1;
 
-        // If the value is 0, 1, 2, 3, warp that to min, min+1, min+2, min+3. Similarly for the UINT256_MAX side.
+        // If the value is 0, 1, 2, 3, wrap that to min, min+1, min+2, min+3. Similarly for the UINT256_MAX side.
         // This helps ensure coverage of the min/max values.
         if (x <= 3 && size > x) return min + x;
         if (x >= UINT256_MAX - 3 && size > UINT256_MAX - x) return max - (UINT256_MAX - x);
@@ -59,7 +60,7 @@ abstract contract StdUtils {
         console2_log("Bound Result", result);
     }
 
-    function bound(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
+    function _bound(int256 x, int256 min, int256 max) internal pure virtual returns (int256 result) {
         require(min <= max, "StdUtils bound(int256,int256,int256): Max is less than min.");
 
         // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
@@ -77,7 +78,15 @@ abstract contract StdUtils {
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
         result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1) : int256(y - INT256_MIN_ABS);
+    }
+
+    function bound(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
+        result = _bound(x, min, max);
         console2_log("Bound result", vm.toString(result));
+    }
+
+    function boundPrivateKey(uint256 privateKey) internal view virtual returns (uint256 result) {
+        result = _bound(privateKey, 1, SECP256K1_ORDER - 1);
     }
 
     function bytesToUint(bytes memory b) internal pure virtual returns (uint256) {

--- a/lib/forge-std/src/Test.sol
+++ b/lib/forge-std/src/Test.sol
@@ -19,6 +19,7 @@ import {stdMath} from "./StdMath.sol";
 import {StdStorage, stdStorage} from "./StdStorage.sol";
 import {StdUtils} from "./StdUtils.sol";
 import {Vm} from "./Vm.sol";
+import {StdStyle} from "./StdStyle.sol";
 
 // 📦 BOILERPLATE
 import {TestBase} from "./Base.sol";

--- a/lib/forge-std/src/Vm.sol
+++ b/lib/forge-std/src/Vm.sol
@@ -21,6 +21,14 @@ interface VmSafe {
         string url;
     }
 
+    struct DirEntry {
+        string errorMessage;
+        string path;
+        uint64 depth;
+        bool isDir;
+        bool isSymlink;
+    }
+
     struct FsMetadata {
         bool isDir;
         bool isSymlink;
@@ -99,6 +107,8 @@ interface VmSafe {
     function getDeployedCode(string calldata artifactPath) external view returns (bytes memory runtimeBytecode);
     // Labels an address in call traces
     function label(address account, string calldata newLabel) external;
+    // Gets the label for the specified address
+    function getLabel(address account) external returns (string memory label);
     // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
     function broadcast() external;
     // Has the next call (at this call depth only) create a transaction with the address provided as the sender that can later be signed and sent onchain
@@ -113,30 +123,66 @@ interface VmSafe {
     function startBroadcast(uint256 privateKey) external;
     // Stops collecting onchain transactions
     function stopBroadcast() external;
-    // Reads the entire content of file to string
-    function readFile(string calldata path) external view returns (string memory data);
-    // Reads the entire content of file as binary. Path is relative to the project root.
-    function readFileBinary(string calldata path) external view returns (bytes memory data);
-    // Get the path of the current project root
+
+    // Get the path of the current project root.
     function projectRoot() external view returns (string memory path);
-    // Get the metadata for a file/directory
-    function fsMetadata(string calldata fileOrDir) external returns (FsMetadata memory metadata);
-    // Reads next line of file to string
+    // Reads the entire content of file to string. `path` is relative to the project root.
+    function readFile(string calldata path) external view returns (string memory data);
+    // Reads the entire content of file as binary. `path` is relative to the project root.
+    function readFileBinary(string calldata path) external view returns (bytes memory data);
+    // Reads next line of file to string.
     function readLine(string calldata path) external view returns (string memory line);
     // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
+    // `path` is relative to the project root.
     function writeFile(string calldata path, string calldata data) external;
     // Writes binary data to a file, creating a file if it does not exist, and entirely replacing its contents if it does.
-    // Path is relative to the project root.
+    // `path` is relative to the project root.
     function writeFileBinary(string calldata path, bytes calldata data) external;
     // Writes line to file, creating a file if it does not exist.
+    // `path` is relative to the project root.
     function writeLine(string calldata path, string calldata data) external;
     // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
+    // `path` is relative to the project root.
     function closeFile(string calldata path) external;
-    // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
-    // - Path points to a directory.
+    // Removes a file from the filesystem.
+    // This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - `path` points to a directory.
     // - The file doesn't exist.
     // - The user lacks permissions to remove the file.
+    // `path` is relative to the project root.
     function removeFile(string calldata path) external;
+    // Creates a new, empty directory at the provided path.
+    // This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - User lacks permissions to modify `path`.
+    // - A parent of the given path doesn't exist and `recursive` is false.
+    // - `path` already exists and `recursive` is false.
+    // `path` is relative to the project root.
+    function createDir(string calldata path, bool recursive) external;
+    // Removes a directory at the provided path.
+    // This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - `path` doesn't exist.
+    // - `path` isn't a directory.
+    // - User lacks permissions to modify `path`.
+    // - The directory is not empty and `recursive` is false.
+    // `path` is relative to the project root.
+    function removeDir(string calldata path, bool recursive) external;
+    // Reads the directory at the given path recursively, up to `max_depth`.
+    // `max_depth` defaults to 1, meaning only the direct children of the given directory will be returned.
+    // Follows symbolic links if `follow_links` is true.
+    function readDir(string calldata path) external view returns (DirEntry[] memory entries);
+    function readDir(string calldata path, uint64 maxDepth) external view returns (DirEntry[] memory entries);
+    function readDir(string calldata path, uint64 maxDepth, bool followLinks)
+        external
+        view
+        returns (DirEntry[] memory entries);
+    // Reads a symbolic link, returning the path that the link points to.
+    // This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - `path` is not a symbolic link.
+    // - `path` does not exist.
+    function readLink(string calldata linkPath) external view returns (string memory targetPath);
+    // Given a path, query the file system to get information about a file, directory, etc.
+    function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
+
     // Convert values to a string
     function toString(address value) external pure returns (string memory stringifiedValue);
     function toString(bytes calldata value) external pure returns (string memory stringifiedValue);
@@ -291,6 +337,10 @@ interface VmSafe {
     function pauseGasMetering() external;
     // Resumes gas metering (i.e. gas usage is counted again). Noop if already on.
     function resumeGasMetering() external;
+    // Writes a breakpoint to jump to in the debugger
+    function breakpoint(string calldata char) external;
+    // Writes a conditional breakpoint to jump to in the debugger
+    function breakpoint(string calldata char, bool value) external;
 }
 
 interface Vm is VmSafe {
@@ -301,13 +351,25 @@ interface Vm is VmSafe {
     // Sets block.basefee
     function fee(uint256 newBasefee) external;
     // Sets block.difficulty
+    // Not available on EVM versions from Paris onwards. Use `prevrandao` instead.
+    // If used on unsupported EVM versions it will revert.
     function difficulty(uint256 newDifficulty) external;
+    // Sets block.prevrandao
+    // Not available on EVM versions before Paris. Use `difficulty` instead.
+    // If used on unsupported EVM versions it will revert.
+    function prevrandao(bytes32 newPrevrandao) external;
     // Sets block.chainid
     function chainId(uint256 newChainId) external;
+    // Sets tx.gasprice
+    function txGasPrice(uint256 newGasPrice) external;
     // Stores a value to an address' storage slot.
     function store(address target, bytes32 slot, bytes32 value) external;
     // Sets the nonce of an account; must be higher than the current nonce of the account
     function setNonce(address account, uint64 newNonce) external;
+    // Sets the nonce of an account to an arbitrary value
+    function setNonceUnsafe(address account, uint64 newNonce) external;
+    // Resets the nonce of an account to 0 for EOAs and 1 for contract accounts
+    function resetNonce(address account) external;
     // Sets the *next* call's msg.sender to be the input address
     function prank(address msgSender) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
@@ -326,12 +388,22 @@ interface Vm is VmSafe {
     function expectRevert(bytes calldata revertData) external;
     function expectRevert(bytes4 revertData) external;
     function expectRevert() external;
+
+    // Prepare an expected log with all four checks enabled.
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emitted in the expected order with the expected topics and data.
+    // Second form also checks supplied address against emitting contract.
+    function expectEmit() external;
+    function expectEmit(address emitter) external;
+
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
-    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans).
+    // Second form also checks supplied address against emitting contract.
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter)
         external;
+
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
@@ -340,13 +412,38 @@ interface Vm is VmSafe {
     // Mocks a call to an address with a specific msg.value, returning specified data.
     // Calldata match takes precedence over msg.value in case of ambiguity.
     function mockCall(address callee, uint256 msgValue, bytes calldata data, bytes calldata returnData) external;
+    // Reverts a call to an address with specified revert data.
+    function mockCallRevert(address callee, bytes calldata data, bytes calldata revertData) external;
+    // Reverts a call to an address with a specific msg.value, with specified revert data.
+    function mockCallRevert(address callee, uint256 msgValue, bytes calldata data, bytes calldata revertData)
+        external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expects a call to an address with the specified calldata.
     // Calldata can either be a strict or a partial match
     function expectCall(address callee, bytes calldata data) external;
+    // Expects given number of calls to an address with the specified calldata.
+    function expectCall(address callee, bytes calldata data, uint64 count) external;
     // Expects a call to an address with the specified msg.value and calldata
     function expectCall(address callee, uint256 msgValue, bytes calldata data) external;
+    // Expects given number of calls to an address with the specified msg.value and calldata
+    function expectCall(address callee, uint256 msgValue, bytes calldata data, uint64 count) external;
+    // Expect a call to an address with the specified msg.value, gas, and calldata.
+    function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data) external;
+    // Expects given number of calls to an address with the specified msg.value, gas, and calldata.
+    function expectCall(address callee, uint256 msgValue, uint64 gas, bytes calldata data, uint64 count) external;
+    // Expect a call to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
+    function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data) external;
+    // Expect given number of calls to an address with the specified msg.value and calldata, and a *minimum* amount of gas.
+    function expectCallMinGas(address callee, uint256 msgValue, uint64 minGas, bytes calldata data, uint64 count)
+        external;
+    // Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the current subcontext. If any other
+    // memory is written to, the test will fail. Can be called multiple times to add more ranges to the set.
+    function expectSafeMemory(uint64 min, uint64 max) external;
+    // Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the next created subcontext.
+    // If any other memory is written to, the test will fail. Can be called multiple times to add more ranges
+    // to the set.
+    function expectSafeMemoryCall(uint64 min, uint64 max) external;
     // Sets block.coinbase
     function coinbase(address newCoinbase) external;
     // Snapshot the current state of the evm.

--- a/lib/forge-std/src/console2.sol
+++ b/lib/forge-std/src/console2.sol
@@ -9,7 +9,19 @@ pragma solidity >=0.4.22 <0.9.0;
 library console2 {
     address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
 
-    function _sendLogPayload(bytes memory payload) private view {
+    function _castLogPayloadViewToPure(
+        function(bytes memory) internal view fnIn
+    ) internal pure returns (function(bytes memory) internal pure fnOut) {
+        assembly {
+            fnOut := fnIn
+        }
+    }
+
+    function _sendLogPayload(bytes memory payload) internal pure {
+        _castLogPayloadViewToPure(_sendLogPayloadView)(payload);
+    }
+
+    function _sendLogPayloadView(bytes memory payload) private view {
         uint256 payloadLength = payload.length;
         address consoleAddress = CONSOLE_ADDRESS;
         /// @solidity memory-safe-assembly
@@ -19,1527 +31,1527 @@ library console2 {
         }
     }
 
-    function log() internal view {
+    function log() internal pure {
         _sendLogPayload(abi.encodeWithSignature("log()"));
     }
 
-    function logInt(int256 p0) internal view {
+    function logInt(int256 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
     }
 
-    function logUint(uint256 p0) internal view {
+    function logUint(uint256 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
     }
 
-    function logString(string memory p0) internal view {
+    function logString(string memory p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
     }
 
-    function logBool(bool p0) internal view {
+    function logBool(bool p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
     }
 
-    function logAddress(address p0) internal view {
+    function logAddress(address p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
     }
 
-    function logBytes(bytes memory p0) internal view {
+    function logBytes(bytes memory p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes)", p0));
     }
 
-    function logBytes1(bytes1 p0) internal view {
+    function logBytes1(bytes1 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes1)", p0));
     }
 
-    function logBytes2(bytes2 p0) internal view {
+    function logBytes2(bytes2 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes2)", p0));
     }
 
-    function logBytes3(bytes3 p0) internal view {
+    function logBytes3(bytes3 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes3)", p0));
     }
 
-    function logBytes4(bytes4 p0) internal view {
+    function logBytes4(bytes4 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes4)", p0));
     }
 
-    function logBytes5(bytes5 p0) internal view {
+    function logBytes5(bytes5 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes5)", p0));
     }
 
-    function logBytes6(bytes6 p0) internal view {
+    function logBytes6(bytes6 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes6)", p0));
     }
 
-    function logBytes7(bytes7 p0) internal view {
+    function logBytes7(bytes7 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes7)", p0));
     }
 
-    function logBytes8(bytes8 p0) internal view {
+    function logBytes8(bytes8 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes8)", p0));
     }
 
-    function logBytes9(bytes9 p0) internal view {
+    function logBytes9(bytes9 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes9)", p0));
     }
 
-    function logBytes10(bytes10 p0) internal view {
+    function logBytes10(bytes10 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes10)", p0));
     }
 
-    function logBytes11(bytes11 p0) internal view {
+    function logBytes11(bytes11 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes11)", p0));
     }
 
-    function logBytes12(bytes12 p0) internal view {
+    function logBytes12(bytes12 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes12)", p0));
     }
 
-    function logBytes13(bytes13 p0) internal view {
+    function logBytes13(bytes13 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes13)", p0));
     }
 
-    function logBytes14(bytes14 p0) internal view {
+    function logBytes14(bytes14 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes14)", p0));
     }
 
-    function logBytes15(bytes15 p0) internal view {
+    function logBytes15(bytes15 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes15)", p0));
     }
 
-    function logBytes16(bytes16 p0) internal view {
+    function logBytes16(bytes16 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes16)", p0));
     }
 
-    function logBytes17(bytes17 p0) internal view {
+    function logBytes17(bytes17 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes17)", p0));
     }
 
-    function logBytes18(bytes18 p0) internal view {
+    function logBytes18(bytes18 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes18)", p0));
     }
 
-    function logBytes19(bytes19 p0) internal view {
+    function logBytes19(bytes19 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes19)", p0));
     }
 
-    function logBytes20(bytes20 p0) internal view {
+    function logBytes20(bytes20 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes20)", p0));
     }
 
-    function logBytes21(bytes21 p0) internal view {
+    function logBytes21(bytes21 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes21)", p0));
     }
 
-    function logBytes22(bytes22 p0) internal view {
+    function logBytes22(bytes22 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes22)", p0));
     }
 
-    function logBytes23(bytes23 p0) internal view {
+    function logBytes23(bytes23 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes23)", p0));
     }
 
-    function logBytes24(bytes24 p0) internal view {
+    function logBytes24(bytes24 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes24)", p0));
     }
 
-    function logBytes25(bytes25 p0) internal view {
+    function logBytes25(bytes25 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes25)", p0));
     }
 
-    function logBytes26(bytes26 p0) internal view {
+    function logBytes26(bytes26 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes26)", p0));
     }
 
-    function logBytes27(bytes27 p0) internal view {
+    function logBytes27(bytes27 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes27)", p0));
     }
 
-    function logBytes28(bytes28 p0) internal view {
+    function logBytes28(bytes28 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes28)", p0));
     }
 
-    function logBytes29(bytes29 p0) internal view {
+    function logBytes29(bytes29 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes29)", p0));
     }
 
-    function logBytes30(bytes30 p0) internal view {
+    function logBytes30(bytes30 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes30)", p0));
     }
 
-    function logBytes31(bytes31 p0) internal view {
+    function logBytes31(bytes31 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes31)", p0));
     }
 
-    function logBytes32(bytes32 p0) internal view {
+    function logBytes32(bytes32 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
     }
 
-    function log(uint256 p0) internal view {
+    function log(uint256 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
     }
 
-    function log(int256 p0) internal view {
+    function log(int256 p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
     }
 
-    function log(string memory p0) internal view {
+    function log(string memory p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
     }
 
-    function log(bool p0) internal view {
+    function log(bool p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool)", p0));
     }
 
-    function log(address p0) internal view {
+    function log(address p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
     }
 
-    function log(uint256 p0, uint256 p1) internal view {
+    function log(uint256 p0, uint256 p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256)", p0, p1));
     }
 
-    function log(uint256 p0, string memory p1) internal view {
+    function log(uint256 p0, string memory p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string)", p0, p1));
     }
 
-    function log(uint256 p0, bool p1) internal view {
+    function log(uint256 p0, bool p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool)", p0, p1));
     }
 
-    function log(uint256 p0, address p1) internal view {
+    function log(uint256 p0, address p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address)", p0, p1));
     }
 
-    function log(string memory p0, uint256 p1) internal view {
+    function log(string memory p0, uint256 p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
     }
 
-    function log(string memory p0, int256 p1) internal view {
+    function log(string memory p0, int256 p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,int256)", p0, p1));
     }
 
-    function log(string memory p0, string memory p1) internal view {
+    function log(string memory p0, string memory p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
     }
 
-    function log(string memory p0, bool p1) internal view {
+    function log(string memory p0, bool p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool)", p0, p1));
     }
 
-    function log(string memory p0, address p1) internal view {
+    function log(string memory p0, address p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
     }
 
-    function log(bool p0, uint256 p1) internal view {
+    function log(bool p0, uint256 p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256)", p0, p1));
     }
 
-    function log(bool p0, string memory p1) internal view {
+    function log(bool p0, string memory p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string)", p0, p1));
     }
 
-    function log(bool p0, bool p1) internal view {
+    function log(bool p0, bool p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool)", p0, p1));
     }
 
-    function log(bool p0, address p1) internal view {
+    function log(bool p0, address p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
     }
 
-    function log(address p0, uint256 p1) internal view {
+    function log(address p0, uint256 p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256)", p0, p1));
     }
 
-    function log(address p0, string memory p1) internal view {
+    function log(address p0, string memory p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string)", p0, p1));
     }
 
-    function log(address p0, bool p1) internal view {
+    function log(address p0, bool p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool)", p0, p1));
     }
 
-    function log(address p0, address p1) internal view {
+    function log(address p0, address p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
     }
 
-    function log(uint256 p0, uint256 p1, uint256 p2) internal view {
+    function log(uint256 p0, uint256 p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(uint256 p0, uint256 p1, string memory p2) internal view {
+    function log(uint256 p0, uint256 p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string)", p0, p1, p2));
     }
 
-    function log(uint256 p0, uint256 p1, bool p2) internal view {
+    function log(uint256 p0, uint256 p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool)", p0, p1, p2));
     }
 
-    function log(uint256 p0, uint256 p1, address p2) internal view {
+    function log(uint256 p0, uint256 p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address)", p0, p1, p2));
     }
 
-    function log(uint256 p0, string memory p1, uint256 p2) internal view {
+    function log(uint256 p0, string memory p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256)", p0, p1, p2));
     }
 
-    function log(uint256 p0, string memory p1, string memory p2) internal view {
+    function log(uint256 p0, string memory p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string)", p0, p1, p2));
     }
 
-    function log(uint256 p0, string memory p1, bool p2) internal view {
+    function log(uint256 p0, string memory p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool)", p0, p1, p2));
     }
 
-    function log(uint256 p0, string memory p1, address p2) internal view {
+    function log(uint256 p0, string memory p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address)", p0, p1, p2));
     }
 
-    function log(uint256 p0, bool p1, uint256 p2) internal view {
+    function log(uint256 p0, bool p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256)", p0, p1, p2));
     }
 
-    function log(uint256 p0, bool p1, string memory p2) internal view {
+    function log(uint256 p0, bool p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string)", p0, p1, p2));
     }
 
-    function log(uint256 p0, bool p1, bool p2) internal view {
+    function log(uint256 p0, bool p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool)", p0, p1, p2));
     }
 
-    function log(uint256 p0, bool p1, address p2) internal view {
+    function log(uint256 p0, bool p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address)", p0, p1, p2));
     }
 
-    function log(uint256 p0, address p1, uint256 p2) internal view {
+    function log(uint256 p0, address p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256)", p0, p1, p2));
     }
 
-    function log(uint256 p0, address p1, string memory p2) internal view {
+    function log(uint256 p0, address p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string)", p0, p1, p2));
     }
 
-    function log(uint256 p0, address p1, bool p2) internal view {
+    function log(uint256 p0, address p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool)", p0, p1, p2));
     }
 
-    function log(uint256 p0, address p1, address p2) internal view {
+    function log(uint256 p0, address p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint256 p1, uint256 p2) internal view {
+    function log(string memory p0, uint256 p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint256 p1, string memory p2) internal view {
+    function log(string memory p0, uint256 p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint256 p1, bool p2) internal view {
+    function log(string memory p0, uint256 p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint256 p1, address p2) internal view {
+    function log(string memory p0, uint256 p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, string memory p1, uint256 p2) internal view {
+    function log(string memory p0, string memory p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256)", p0, p1, p2));
     }
 
-    function log(string memory p0, string memory p1, string memory p2) internal view {
+    function log(string memory p0, string memory p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string)", p0, p1, p2));
     }
 
-    function log(string memory p0, string memory p1, bool p2) internal view {
+    function log(string memory p0, string memory p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool)", p0, p1, p2));
     }
 
-    function log(string memory p0, string memory p1, address p2) internal view {
+    function log(string memory p0, string memory p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, bool p1, uint256 p2) internal view {
+    function log(string memory p0, bool p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256)", p0, p1, p2));
     }
 
-    function log(string memory p0, bool p1, string memory p2) internal view {
+    function log(string memory p0, bool p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string)", p0, p1, p2));
     }
 
-    function log(string memory p0, bool p1, bool p2) internal view {
+    function log(string memory p0, bool p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool)", p0, p1, p2));
     }
 
-    function log(string memory p0, bool p1, address p2) internal view {
+    function log(string memory p0, bool p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, address p1, uint256 p2) internal view {
+    function log(string memory p0, address p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256)", p0, p1, p2));
     }
 
-    function log(string memory p0, address p1, string memory p2) internal view {
+    function log(string memory p0, address p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string)", p0, p1, p2));
     }
 
-    function log(string memory p0, address p1, bool p2) internal view {
+    function log(string memory p0, address p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool)", p0, p1, p2));
     }
 
-    function log(string memory p0, address p1, address p2) internal view {
+    function log(string memory p0, address p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
     }
 
-    function log(bool p0, uint256 p1, uint256 p2) internal view {
+    function log(bool p0, uint256 p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(bool p0, uint256 p1, string memory p2) internal view {
+    function log(bool p0, uint256 p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string)", p0, p1, p2));
     }
 
-    function log(bool p0, uint256 p1, bool p2) internal view {
+    function log(bool p0, uint256 p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool)", p0, p1, p2));
     }
 
-    function log(bool p0, uint256 p1, address p2) internal view {
+    function log(bool p0, uint256 p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address)", p0, p1, p2));
     }
 
-    function log(bool p0, string memory p1, uint256 p2) internal view {
+    function log(bool p0, string memory p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256)", p0, p1, p2));
     }
 
-    function log(bool p0, string memory p1, string memory p2) internal view {
+    function log(bool p0, string memory p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string)", p0, p1, p2));
     }
 
-    function log(bool p0, string memory p1, bool p2) internal view {
+    function log(bool p0, string memory p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool)", p0, p1, p2));
     }
 
-    function log(bool p0, string memory p1, address p2) internal view {
+    function log(bool p0, string memory p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
     }
 
-    function log(bool p0, bool p1, uint256 p2) internal view {
+    function log(bool p0, bool p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256)", p0, p1, p2));
     }
 
-    function log(bool p0, bool p1, string memory p2) internal view {
+    function log(bool p0, bool p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string)", p0, p1, p2));
     }
 
-    function log(bool p0, bool p1, bool p2) internal view {
+    function log(bool p0, bool p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool)", p0, p1, p2));
     }
 
-    function log(bool p0, bool p1, address p2) internal view {
+    function log(bool p0, bool p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
     }
 
-    function log(bool p0, address p1, uint256 p2) internal view {
+    function log(bool p0, address p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256)", p0, p1, p2));
     }
 
-    function log(bool p0, address p1, string memory p2) internal view {
+    function log(bool p0, address p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string)", p0, p1, p2));
     }
 
-    function log(bool p0, address p1, bool p2) internal view {
+    function log(bool p0, address p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool)", p0, p1, p2));
     }
 
-    function log(bool p0, address p1, address p2) internal view {
+    function log(bool p0, address p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
     }
 
-    function log(address p0, uint256 p1, uint256 p2) internal view {
+    function log(address p0, uint256 p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(address p0, uint256 p1, string memory p2) internal view {
+    function log(address p0, uint256 p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string)", p0, p1, p2));
     }
 
-    function log(address p0, uint256 p1, bool p2) internal view {
+    function log(address p0, uint256 p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool)", p0, p1, p2));
     }
 
-    function log(address p0, uint256 p1, address p2) internal view {
+    function log(address p0, uint256 p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address)", p0, p1, p2));
     }
 
-    function log(address p0, string memory p1, uint256 p2) internal view {
+    function log(address p0, string memory p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256)", p0, p1, p2));
     }
 
-    function log(address p0, string memory p1, string memory p2) internal view {
+    function log(address p0, string memory p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string)", p0, p1, p2));
     }
 
-    function log(address p0, string memory p1, bool p2) internal view {
+    function log(address p0, string memory p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool)", p0, p1, p2));
     }
 
-    function log(address p0, string memory p1, address p2) internal view {
+    function log(address p0, string memory p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
     }
 
-    function log(address p0, bool p1, uint256 p2) internal view {
+    function log(address p0, bool p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256)", p0, p1, p2));
     }
 
-    function log(address p0, bool p1, string memory p2) internal view {
+    function log(address p0, bool p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string)", p0, p1, p2));
     }
 
-    function log(address p0, bool p1, bool p2) internal view {
+    function log(address p0, bool p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool)", p0, p1, p2));
     }
 
-    function log(address p0, bool p1, address p2) internal view {
+    function log(address p0, bool p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
     }
 
-    function log(address p0, address p1, uint256 p2) internal view {
+    function log(address p0, address p1, uint256 p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256)", p0, p1, p2));
     }
 
-    function log(address p0, address p1, string memory p2) internal view {
+    function log(address p0, address p1, string memory p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string)", p0, p1, p2));
     }
 
-    function log(address p0, address p1, bool p2) internal view {
+    function log(address p0, address p1, bool p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool)", p0, p1, p2));
     }
 
-    function log(address p0, address p1, address p2) internal view {
+    function log(address p0, address p1, address p2) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
     }
 
-    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, uint256 p2, string memory p3) internal view {
+    function log(uint256 p0, uint256 p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal view {
+    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal view {
+    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, string memory p2, uint256 p3) internal view {
+    function log(uint256 p0, uint256 p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, string memory p2, string memory p3) internal view {
+    function log(uint256 p0, uint256 p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, string memory p2, bool p3) internal view {
+    function log(uint256 p0, uint256 p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, string memory p2, address p3) internal view {
+    function log(uint256 p0, uint256 p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal view {
+    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, bool p2, string memory p3) internal view {
+    function log(uint256 p0, uint256 p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal view {
+    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, bool p2, address p3) internal view {
+    function log(uint256 p0, uint256 p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal view {
+    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, address p2, string memory p3) internal view {
+    function log(uint256 p0, uint256 p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, address p2, bool p3) internal view {
+    function log(uint256 p0, uint256 p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, uint256 p1, address p2, address p3) internal view {
+    function log(uint256 p0, uint256 p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, uint256 p2, uint256 p3) internal view {
+    function log(uint256 p0, string memory p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, uint256 p2, string memory p3) internal view {
+    function log(uint256 p0, string memory p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, uint256 p2, bool p3) internal view {
+    function log(uint256 p0, string memory p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, uint256 p2, address p3) internal view {
+    function log(uint256 p0, string memory p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, string memory p2, uint256 p3) internal view {
+    function log(uint256 p0, string memory p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, string memory p2, string memory p3) internal view {
+    function log(uint256 p0, string memory p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, string memory p2, bool p3) internal view {
+    function log(uint256 p0, string memory p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, string memory p2, address p3) internal view {
+    function log(uint256 p0, string memory p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, bool p2, uint256 p3) internal view {
+    function log(uint256 p0, string memory p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, bool p2, string memory p3) internal view {
+    function log(uint256 p0, string memory p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, bool p2, bool p3) internal view {
+    function log(uint256 p0, string memory p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, bool p2, address p3) internal view {
+    function log(uint256 p0, string memory p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, address p2, uint256 p3) internal view {
+    function log(uint256 p0, string memory p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, address p2, string memory p3) internal view {
+    function log(uint256 p0, string memory p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, address p2, bool p3) internal view {
+    function log(uint256 p0, string memory p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, string memory p1, address p2, address p3) internal view {
+    function log(uint256 p0, string memory p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal view {
+    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, uint256 p2, string memory p3) internal view {
+    function log(uint256 p0, bool p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal view {
+    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, uint256 p2, address p3) internal view {
+    function log(uint256 p0, bool p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, string memory p2, uint256 p3) internal view {
+    function log(uint256 p0, bool p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, string memory p2, string memory p3) internal view {
+    function log(uint256 p0, bool p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, string memory p2, bool p3) internal view {
+    function log(uint256 p0, bool p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, string memory p2, address p3) internal view {
+    function log(uint256 p0, bool p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal view {
+    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, bool p2, string memory p3) internal view {
+    function log(uint256 p0, bool p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, bool p2, bool p3) internal view {
+    function log(uint256 p0, bool p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, bool p2, address p3) internal view {
+    function log(uint256 p0, bool p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, address p2, uint256 p3) internal view {
+    function log(uint256 p0, bool p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, address p2, string memory p3) internal view {
+    function log(uint256 p0, bool p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, address p2, bool p3) internal view {
+    function log(uint256 p0, bool p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, bool p1, address p2, address p3) internal view {
+    function log(uint256 p0, bool p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal view {
+    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, uint256 p2, string memory p3) internal view {
+    function log(uint256 p0, address p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, uint256 p2, bool p3) internal view {
+    function log(uint256 p0, address p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, uint256 p2, address p3) internal view {
+    function log(uint256 p0, address p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, string memory p2, uint256 p3) internal view {
+    function log(uint256 p0, address p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, string memory p2, string memory p3) internal view {
+    function log(uint256 p0, address p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, string memory p2, bool p3) internal view {
+    function log(uint256 p0, address p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, string memory p2, address p3) internal view {
+    function log(uint256 p0, address p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, bool p2, uint256 p3) internal view {
+    function log(uint256 p0, address p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, bool p2, string memory p3) internal view {
+    function log(uint256 p0, address p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, bool p2, bool p3) internal view {
+    function log(uint256 p0, address p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, bool p2, address p3) internal view {
+    function log(uint256 p0, address p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, address p2, uint256 p3) internal view {
+    function log(uint256 p0, address p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, address p2, string memory p3) internal view {
+    function log(uint256 p0, address p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, address p2, bool p3) internal view {
+    function log(uint256 p0, address p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint256 p0, address p1, address p2, address p3) internal view {
+    function log(uint256 p0, address p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+    function log(string memory p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, uint256 p2, string memory p3) internal view {
+    function log(string memory p0, uint256 p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, uint256 p2, bool p3) internal view {
+    function log(string memory p0, uint256 p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, uint256 p2, address p3) internal view {
+    function log(string memory p0, uint256 p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, string memory p2, uint256 p3) internal view {
+    function log(string memory p0, uint256 p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, string memory p2, string memory p3) internal view {
+    function log(string memory p0, uint256 p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, string memory p2, bool p3) internal view {
+    function log(string memory p0, uint256 p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, string memory p2, address p3) internal view {
+    function log(string memory p0, uint256 p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, bool p2, uint256 p3) internal view {
+    function log(string memory p0, uint256 p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, bool p2, string memory p3) internal view {
+    function log(string memory p0, uint256 p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, bool p2, bool p3) internal view {
+    function log(string memory p0, uint256 p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, bool p2, address p3) internal view {
+    function log(string memory p0, uint256 p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, address p2, uint256 p3) internal view {
+    function log(string memory p0, uint256 p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, address p2, string memory p3) internal view {
+    function log(string memory p0, uint256 p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, address p2, bool p3) internal view {
+    function log(string memory p0, uint256 p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint256 p1, address p2, address p3) internal view {
+    function log(string memory p0, uint256 p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint256 p2, uint256 p3) internal view {
+    function log(string memory p0, string memory p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint256 p2, string memory p3) internal view {
+    function log(string memory p0, string memory p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint256 p2, bool p3) internal view {
+    function log(string memory p0, string memory p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint256 p2, address p3) internal view {
+    function log(string memory p0, string memory p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, string memory p2, uint256 p3) internal view {
+    function log(string memory p0, string memory p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, string memory p2, string memory p3) internal view {
+    function log(string memory p0, string memory p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, string memory p2, bool p3) internal view {
+    function log(string memory p0, string memory p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, string memory p2, address p3) internal view {
+    function log(string memory p0, string memory p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, bool p2, uint256 p3) internal view {
+    function log(string memory p0, string memory p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, bool p2, string memory p3) internal view {
+    function log(string memory p0, string memory p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, bool p2, bool p3) internal view {
+    function log(string memory p0, string memory p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, bool p2, address p3) internal view {
+    function log(string memory p0, string memory p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, address p2, uint256 p3) internal view {
+    function log(string memory p0, string memory p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, address p2, string memory p3) internal view {
+    function log(string memory p0, string memory p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, address p2, bool p3) internal view {
+    function log(string memory p0, string memory p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, address p2, address p3) internal view {
+    function log(string memory p0, string memory p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint256 p2, uint256 p3) internal view {
+    function log(string memory p0, bool p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint256 p2, string memory p3) internal view {
+    function log(string memory p0, bool p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint256 p2, bool p3) internal view {
+    function log(string memory p0, bool p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint256 p2, address p3) internal view {
+    function log(string memory p0, bool p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, string memory p2, uint256 p3) internal view {
+    function log(string memory p0, bool p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, string memory p2, string memory p3) internal view {
+    function log(string memory p0, bool p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, string memory p2, bool p3) internal view {
+    function log(string memory p0, bool p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, string memory p2, address p3) internal view {
+    function log(string memory p0, bool p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, bool p2, uint256 p3) internal view {
+    function log(string memory p0, bool p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, bool p2, string memory p3) internal view {
+    function log(string memory p0, bool p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, bool p2, bool p3) internal view {
+    function log(string memory p0, bool p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, bool p2, address p3) internal view {
+    function log(string memory p0, bool p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, address p2, uint256 p3) internal view {
+    function log(string memory p0, bool p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, address p2, string memory p3) internal view {
+    function log(string memory p0, bool p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, address p2, bool p3) internal view {
+    function log(string memory p0, bool p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, address p2, address p3) internal view {
+    function log(string memory p0, bool p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint256 p2, uint256 p3) internal view {
+    function log(string memory p0, address p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint256 p2, string memory p3) internal view {
+    function log(string memory p0, address p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint256 p2, bool p3) internal view {
+    function log(string memory p0, address p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint256 p2, address p3) internal view {
+    function log(string memory p0, address p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, string memory p2, uint256 p3) internal view {
+    function log(string memory p0, address p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, string memory p2, string memory p3) internal view {
+    function log(string memory p0, address p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, string memory p2, bool p3) internal view {
+    function log(string memory p0, address p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, string memory p2, address p3) internal view {
+    function log(string memory p0, address p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, bool p2, uint256 p3) internal view {
+    function log(string memory p0, address p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, bool p2, string memory p3) internal view {
+    function log(string memory p0, address p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, bool p2, bool p3) internal view {
+    function log(string memory p0, address p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, bool p2, address p3) internal view {
+    function log(string memory p0, address p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, address p2, uint256 p3) internal view {
+    function log(string memory p0, address p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, address p2, string memory p3) internal view {
+    function log(string memory p0, address p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, address p2, bool p3) internal view {
+    function log(string memory p0, address p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, address p2, address p3) internal view {
+    function log(string memory p0, address p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, uint256 p2, string memory p3) internal view {
+    function log(bool p0, uint256 p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal view {
+    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, uint256 p2, address p3) internal view {
+    function log(bool p0, uint256 p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, string memory p2, uint256 p3) internal view {
+    function log(bool p0, uint256 p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, string memory p2, string memory p3) internal view {
+    function log(bool p0, uint256 p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, string memory p2, bool p3) internal view {
+    function log(bool p0, uint256 p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, string memory p2, address p3) internal view {
+    function log(bool p0, uint256 p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal view {
+    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, bool p2, string memory p3) internal view {
+    function log(bool p0, uint256 p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, bool p2, bool p3) internal view {
+    function log(bool p0, uint256 p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, bool p2, address p3) internal view {
+    function log(bool p0, uint256 p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, address p2, uint256 p3) internal view {
+    function log(bool p0, uint256 p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, address p2, string memory p3) internal view {
+    function log(bool p0, uint256 p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, address p2, bool p3) internal view {
+    function log(bool p0, uint256 p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint256 p1, address p2, address p3) internal view {
+    function log(bool p0, uint256 p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint256 p2, uint256 p3) internal view {
+    function log(bool p0, string memory p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint256 p2, string memory p3) internal view {
+    function log(bool p0, string memory p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint256 p2, bool p3) internal view {
+    function log(bool p0, string memory p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint256 p2, address p3) internal view {
+    function log(bool p0, string memory p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, string memory p2, uint256 p3) internal view {
+    function log(bool p0, string memory p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, string memory p2, string memory p3) internal view {
+    function log(bool p0, string memory p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, string memory p2, bool p3) internal view {
+    function log(bool p0, string memory p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, string memory p2, address p3) internal view {
+    function log(bool p0, string memory p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, bool p2, uint256 p3) internal view {
+    function log(bool p0, string memory p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, bool p2, string memory p3) internal view {
+    function log(bool p0, string memory p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, bool p2, bool p3) internal view {
+    function log(bool p0, string memory p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, bool p2, address p3) internal view {
+    function log(bool p0, string memory p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, address p2, uint256 p3) internal view {
+    function log(bool p0, string memory p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, address p2, string memory p3) internal view {
+    function log(bool p0, string memory p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, address p2, bool p3) internal view {
+    function log(bool p0, string memory p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, address p2, address p3) internal view {
+    function log(bool p0, string memory p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal view {
+    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint256 p2, string memory p3) internal view {
+    function log(bool p0, bool p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint256 p2, bool p3) internal view {
+    function log(bool p0, bool p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint256 p2, address p3) internal view {
+    function log(bool p0, bool p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, string memory p2, uint256 p3) internal view {
+    function log(bool p0, bool p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, string memory p2, string memory p3) internal view {
+    function log(bool p0, bool p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, string memory p2, bool p3) internal view {
+    function log(bool p0, bool p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, string memory p2, address p3) internal view {
+    function log(bool p0, bool p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, bool p2, uint256 p3) internal view {
+    function log(bool p0, bool p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, bool p2, string memory p3) internal view {
+    function log(bool p0, bool p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, bool p2, bool p3) internal view {
+    function log(bool p0, bool p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, bool p2, address p3) internal view {
+    function log(bool p0, bool p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, address p2, uint256 p3) internal view {
+    function log(bool p0, bool p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, address p2, string memory p3) internal view {
+    function log(bool p0, bool p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, address p2, bool p3) internal view {
+    function log(bool p0, bool p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, address p2, address p3) internal view {
+    function log(bool p0, bool p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint256 p2, uint256 p3) internal view {
+    function log(bool p0, address p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint256 p2, string memory p3) internal view {
+    function log(bool p0, address p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint256 p2, bool p3) internal view {
+    function log(bool p0, address p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint256 p2, address p3) internal view {
+    function log(bool p0, address p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, string memory p2, uint256 p3) internal view {
+    function log(bool p0, address p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, string memory p2, string memory p3) internal view {
+    function log(bool p0, address p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, string memory p2, bool p3) internal view {
+    function log(bool p0, address p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, string memory p2, address p3) internal view {
+    function log(bool p0, address p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, bool p2, uint256 p3) internal view {
+    function log(bool p0, address p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, bool p2, string memory p3) internal view {
+    function log(bool p0, address p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, bool p2, bool p3) internal view {
+    function log(bool p0, address p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, bool p2, address p3) internal view {
+    function log(bool p0, address p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, address p2, uint256 p3) internal view {
+    function log(bool p0, address p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, address p2, string memory p3) internal view {
+    function log(bool p0, address p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, address p2, bool p3) internal view {
+    function log(bool p0, address p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, address p2, address p3) internal view {
+    function log(bool p0, address p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal view {
+    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, uint256 p2, string memory p3) internal view {
+    function log(address p0, uint256 p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, uint256 p2, bool p3) internal view {
+    function log(address p0, uint256 p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, uint256 p2, address p3) internal view {
+    function log(address p0, uint256 p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, string memory p2, uint256 p3) internal view {
+    function log(address p0, uint256 p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, string memory p2, string memory p3) internal view {
+    function log(address p0, uint256 p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, string memory p2, bool p3) internal view {
+    function log(address p0, uint256 p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, string memory p2, address p3) internal view {
+    function log(address p0, uint256 p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, bool p2, uint256 p3) internal view {
+    function log(address p0, uint256 p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, bool p2, string memory p3) internal view {
+    function log(address p0, uint256 p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, bool p2, bool p3) internal view {
+    function log(address p0, uint256 p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, bool p2, address p3) internal view {
+    function log(address p0, uint256 p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, address p2, uint256 p3) internal view {
+    function log(address p0, uint256 p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, address p2, string memory p3) internal view {
+    function log(address p0, uint256 p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, address p2, bool p3) internal view {
+    function log(address p0, uint256 p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint256 p1, address p2, address p3) internal view {
+    function log(address p0, uint256 p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint256 p2, uint256 p3) internal view {
+    function log(address p0, string memory p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint256 p2, string memory p3) internal view {
+    function log(address p0, string memory p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint256 p2, bool p3) internal view {
+    function log(address p0, string memory p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint256 p2, address p3) internal view {
+    function log(address p0, string memory p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, string memory p2, uint256 p3) internal view {
+    function log(address p0, string memory p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, string memory p2, string memory p3) internal view {
+    function log(address p0, string memory p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, string memory p2, bool p3) internal view {
+    function log(address p0, string memory p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, string memory p2, address p3) internal view {
+    function log(address p0, string memory p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, bool p2, uint256 p3) internal view {
+    function log(address p0, string memory p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, bool p2, string memory p3) internal view {
+    function log(address p0, string memory p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, bool p2, bool p3) internal view {
+    function log(address p0, string memory p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, bool p2, address p3) internal view {
+    function log(address p0, string memory p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, address p2, uint256 p3) internal view {
+    function log(address p0, string memory p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, address p2, string memory p3) internal view {
+    function log(address p0, string memory p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, address p2, bool p3) internal view {
+    function log(address p0, string memory p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, address p2, address p3) internal view {
+    function log(address p0, string memory p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint256 p2, uint256 p3) internal view {
+    function log(address p0, bool p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint256 p2, string memory p3) internal view {
+    function log(address p0, bool p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint256 p2, bool p3) internal view {
+    function log(address p0, bool p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint256 p2, address p3) internal view {
+    function log(address p0, bool p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, string memory p2, uint256 p3) internal view {
+    function log(address p0, bool p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, string memory p2, string memory p3) internal view {
+    function log(address p0, bool p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, string memory p2, bool p3) internal view {
+    function log(address p0, bool p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, string memory p2, address p3) internal view {
+    function log(address p0, bool p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, bool p2, uint256 p3) internal view {
+    function log(address p0, bool p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, bool p2, string memory p3) internal view {
+    function log(address p0, bool p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, bool p2, bool p3) internal view {
+    function log(address p0, bool p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, bool p2, address p3) internal view {
+    function log(address p0, bool p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, address p2, uint256 p3) internal view {
+    function log(address p0, bool p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, address p2, string memory p3) internal view {
+    function log(address p0, bool p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, address p2, bool p3) internal view {
+    function log(address p0, bool p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, address p2, address p3) internal view {
+    function log(address p0, bool p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint256 p2, uint256 p3) internal view {
+    function log(address p0, address p1, uint256 p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint256 p2, string memory p3) internal view {
+    function log(address p0, address p1, uint256 p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint256 p2, bool p3) internal view {
+    function log(address p0, address p1, uint256 p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint256 p2, address p3) internal view {
+    function log(address p0, address p1, uint256 p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, string memory p2, uint256 p3) internal view {
+    function log(address p0, address p1, string memory p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, string memory p2, string memory p3) internal view {
+    function log(address p0, address p1, string memory p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, string memory p2, bool p3) internal view {
+    function log(address p0, address p1, string memory p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, string memory p2, address p3) internal view {
+    function log(address p0, address p1, string memory p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, bool p2, uint256 p3) internal view {
+    function log(address p0, address p1, bool p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, bool p2, string memory p3) internal view {
+    function log(address p0, address p1, bool p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, bool p2, bool p3) internal view {
+    function log(address p0, address p1, bool p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, bool p2, address p3) internal view {
+    function log(address p0, address p1, bool p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, address p2, uint256 p3) internal view {
+    function log(address p0, address p1, address p2, uint256 p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, address p2, string memory p3) internal view {
+    function log(address p0, address p1, address p2, string memory p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, address p2, bool p3) internal view {
+    function log(address p0, address p1, address p2, bool p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, address p2, address p3) internal view {
+    function log(address p0, address p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
     }
 

--- a/lib/forge-std/src/safeconsole.sol
+++ b/lib/forge-std/src/safeconsole.sol
@@ -1,0 +1,13248 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+/// @author philogy <https://github.com/philogy>
+/// @dev Code generated automatically by script.
+library safeconsole {
+    uint256 constant CONSOLE_ADDR = 0x000000000000000000000000000000000000000000636F6e736F6c652e6c6f67;
+
+    // Credit to [0age](https://twitter.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
+    // for the view-to-pure log trick.
+    function _sendLogPayload(uint256 offset, uint256 size) private pure {
+        function(uint256, uint256) internal view fnIn = _sendLogPayloadView;
+        function(uint256, uint256) internal pure pureSendLogPayload;
+        assembly {
+            pureSendLogPayload := fnIn
+        }
+        pureSendLogPayload(offset, size);
+    }
+
+    function _sendLogPayloadView(uint256 offset, uint256 size) private view {
+        assembly {
+            pop(staticcall(gas(), CONSOLE_ADDR, offset, size, 0x0, 0x0))
+        }
+    }
+
+    function _memcopy(uint256 fromOffset, uint256 toOffset, uint256 length) private pure {
+        function(uint256, uint256, uint256) internal view fnIn = _memcopyView;
+        function(uint256, uint256, uint256) internal pure pureMemcopy;
+        assembly {
+            pureMemcopy := fnIn
+        }
+        pureMemcopy(fromOffset, toOffset, length);
+    }
+
+    function _memcopyView(uint256 fromOffset, uint256 toOffset, uint256 length) private view {
+        assembly {
+            pop(staticcall(gas(), 0x4, fromOffset, length, toOffset, length))
+        }
+    }
+
+    function logMemory(uint256 offset, uint256 length) internal pure {
+        if (offset >= 0x60) {
+            // Sufficient memory before slice to prepare call header.
+            bytes32 m0;
+            bytes32 m1;
+            bytes32 m2;
+            assembly {
+                m0 := mload(sub(offset, 0x60))
+                m1 := mload(sub(offset, 0x40))
+                m2 := mload(sub(offset, 0x20))
+                // Selector of `logBytes(bytes)`.
+                mstore(sub(offset, 0x60), 0xe17bf956)
+                mstore(sub(offset, 0x40), 0x20)
+                mstore(sub(offset, 0x20), length)
+            }
+            _sendLogPayload(offset - 0x44, length + 0x44);
+            assembly {
+                mstore(sub(offset, 0x60), m0)
+                mstore(sub(offset, 0x40), m1)
+                mstore(sub(offset, 0x20), m2)
+            }
+        } else {
+            // Insufficient space, so copy slice forward, add header and reverse.
+            bytes32 m0;
+            bytes32 m1;
+            bytes32 m2;
+            uint256 endOffset = offset + length;
+            assembly {
+                m0 := mload(add(endOffset, 0x00))
+                m1 := mload(add(endOffset, 0x20))
+                m2 := mload(add(endOffset, 0x40))
+            }
+            _memcopy(offset, offset + 0x60, length);
+            assembly {
+                // Selector of `logBytes(bytes)`.
+                mstore(add(offset, 0x00), 0xe17bf956)
+                mstore(add(offset, 0x20), 0x20)
+                mstore(add(offset, 0x40), length)
+            }
+            _sendLogPayload(offset + 0x1c, length + 0x44);
+            _memcopy(offset + 0x60, offset, length);
+            assembly {
+                mstore(add(endOffset, 0x00), m0)
+                mstore(add(endOffset, 0x20), m1)
+                mstore(add(endOffset, 0x40), m2)
+            }
+        }
+    }
+
+    function log(address p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(address)`.
+            mstore(0x00, 0x2c2ecbc2)
+            mstore(0x20, p0)
+        }
+        _sendLogPayload(0x1c, 0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(bool p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(bool)`.
+            mstore(0x00, 0x32458eed)
+            mstore(0x20, p0)
+        }
+        _sendLogPayload(0x1c, 0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(uint256 p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(uint256)`.
+            mstore(0x00, 0xf82c50f1)
+            mstore(0x20, p0)
+        }
+        _sendLogPayload(0x1c, 0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(bytes32 p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(string)`.
+            mstore(0x00, 0x41304fac)
+            mstore(0x20, 0x20)
+            writeString(0x40, p0)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,address)`.
+            mstore(0x00, 0xdaf0d4aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,bool)`.
+            mstore(0x00, 0x75b605d3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,uint256)`.
+            mstore(0x00, 0x8309e8a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,string)`.
+            mstore(0x00, 0x759f86bb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,address)`.
+            mstore(0x00, 0x853c4849)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,bool)`.
+            mstore(0x00, 0x2a110e83)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,uint256)`.
+            mstore(0x00, 0x399174d3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,string)`.
+            mstore(0x00, 0x8feac525)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,address)`.
+            mstore(0x00, 0x69276c86)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,bool)`.
+            mstore(0x00, 0x1c9d7eb3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,uint256)`.
+            mstore(0x00, 0xf666715a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _sendLogPayload(0x1c, 0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,string)`.
+            mstore(0x00, 0x643fd0df)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,address)`.
+            mstore(0x00, 0x319af333)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,bool)`.
+            mstore(0x00, 0xc3b55635)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,uint256)`.
+            mstore(0x00, 0xb60e72cc)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,string)`.
+            mstore(0x00, 0x4b5c4277)
+            mstore(0x20, 0x40)
+            mstore(0x40, 0x80)
+            writeString(0x60, p0)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,address)`.
+            mstore(0x00, 0x018c84c2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,bool)`.
+            mstore(0x00, 0xf2a66286)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,uint256)`.
+            mstore(0x00, 0x17fe6185)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,address,string)`.
+            mstore(0x00, 0x007150be)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,address)`.
+            mstore(0x00, 0xf11699ed)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,bool)`.
+            mstore(0x00, 0xeb830c92)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,uint256)`.
+            mstore(0x00, 0x9c4f99fb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,bool,string)`.
+            mstore(0x00, 0x212255cc)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,address)`.
+            mstore(0x00, 0x7bc0d848)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,bool)`.
+            mstore(0x00, 0x678209a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,uint256)`.
+            mstore(0x00, 0xb69bcaf6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,uint256,string)`.
+            mstore(0x00, 0xa1f2e8aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,address)`.
+            mstore(0x00, 0xf08744e8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,bool)`.
+            mstore(0x00, 0xcf020fb1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,uint256)`.
+            mstore(0x00, 0x67dd6ff1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(address,string,string)`.
+            mstore(0x00, 0xfb772265)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bool p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,address)`.
+            mstore(0x00, 0xd2763667)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,bool)`.
+            mstore(0x00, 0x18c9c746)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,uint256)`.
+            mstore(0x00, 0x5f7b9afb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,address,string)`.
+            mstore(0x00, 0xde9a9270)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,address)`.
+            mstore(0x00, 0x1078f68d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,bool)`.
+            mstore(0x00, 0x50709698)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,uint256)`.
+            mstore(0x00, 0x12f21602)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,bool,string)`.
+            mstore(0x00, 0x2555fa46)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,address)`.
+            mstore(0x00, 0x088ef9d2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,bool)`.
+            mstore(0x00, 0xe8defba9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,uint256)`.
+            mstore(0x00, 0x37103367)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,uint256,string)`.
+            mstore(0x00, 0xc3fc3970)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,address)`.
+            mstore(0x00, 0x9591b953)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,bool)`.
+            mstore(0x00, 0xdbb4c247)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,uint256)`.
+            mstore(0x00, 0x1093ee11)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(bool,string,string)`.
+            mstore(0x00, 0xb076847f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,address)`.
+            mstore(0x00, 0xbcfd9be0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,bool)`.
+            mstore(0x00, 0x9b6ec042)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,uint256)`.
+            mstore(0x00, 0x5a9b5ed5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,address,string)`.
+            mstore(0x00, 0x63cb41f9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,address)`.
+            mstore(0x00, 0x35085f7b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,bool)`.
+            mstore(0x00, 0x20718650)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,uint256)`.
+            mstore(0x00, 0x20098014)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,bool,string)`.
+            mstore(0x00, 0x85775021)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,address)`.
+            mstore(0x00, 0x5c96b331)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,bool)`.
+            mstore(0x00, 0x4766da72)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,uint256)`.
+            mstore(0x00, 0xd1ed7a3c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _sendLogPayload(0x1c, 0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,uint256,string)`.
+            mstore(0x00, 0x71d04af2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,address)`.
+            mstore(0x00, 0x7afac959)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,bool)`.
+            mstore(0x00, 0x4ceda75a)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,uint256)`.
+            mstore(0x00, 0x37aa7d4c)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(uint256,string,string)`.
+            mstore(0x00, 0xb115611f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,address)`.
+            mstore(0x00, 0xfcec75e0)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,bool)`.
+            mstore(0x00, 0xc91d5ed4)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,uint256)`.
+            mstore(0x00, 0x0d26b925)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,address,string)`.
+            mstore(0x00, 0xe0e9ad4f)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,address)`.
+            mstore(0x00, 0x932bbb38)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,bool)`.
+            mstore(0x00, 0x850b7ad6)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,uint256)`.
+            mstore(0x00, 0xc95958d6)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,bool,string)`.
+            mstore(0x00, 0xe298f47d)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,address)`.
+            mstore(0x00, 0x1c7ec448)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,bool)`.
+            mstore(0x00, 0xca7733b1)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,uint256)`.
+            mstore(0x00, 0xca47c4eb)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _sendLogPayload(0x1c, 0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,uint256,string)`.
+            mstore(0x00, 0x5970e089)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,address)`.
+            mstore(0x00, 0x95ed0195)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,bool)`.
+            mstore(0x00, 0xb0e0f9b5)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,uint256)`.
+            mstore(0x00, 0x5821efa1)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _sendLogPayload(0x1c, 0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            // Selector of `log(string,string,string)`.
+            mstore(0x00, 0x2ced7cef)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, 0xe0)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+            writeString(0x100, p2)
+        }
+        _sendLogPayload(0x1c, 0x124);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+        }
+    }
+
+    function log(address p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,address)`.
+            mstore(0x00, 0x665bf134)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,bool)`.
+            mstore(0x00, 0x0e378994)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,uint256)`.
+            mstore(0x00, 0x94250d77)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,address,string)`.
+            mstore(0x00, 0xf808da20)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,address)`.
+            mstore(0x00, 0x9f1bc36e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,bool)`.
+            mstore(0x00, 0x2cd4134a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,uint256)`.
+            mstore(0x00, 0x3971e78c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,bool,string)`.
+            mstore(0x00, 0xaa6540c8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,address)`.
+            mstore(0x00, 0x8da6def5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,bool)`.
+            mstore(0x00, 0x9b4254e2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,uint256)`.
+            mstore(0x00, 0xbe553481)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,uint256,string)`.
+            mstore(0x00, 0xfdb4f990)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,address)`.
+            mstore(0x00, 0x8f736d16)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,bool)`.
+            mstore(0x00, 0x6f1a594e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,uint256)`.
+            mstore(0x00, 0xef1cefe7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,address,string,string)`.
+            mstore(0x00, 0x21bdaf25)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,address)`.
+            mstore(0x00, 0x660375dd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,bool)`.
+            mstore(0x00, 0xa6f50b0f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,uint256)`.
+            mstore(0x00, 0xa75c59de)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,address,string)`.
+            mstore(0x00, 0x2dd778e6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,address)`.
+            mstore(0x00, 0xcf394485)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,bool)`.
+            mstore(0x00, 0xcac43479)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,uint256)`.
+            mstore(0x00, 0x8c4e5de6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,bool,string)`.
+            mstore(0x00, 0xdfc4a2e8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,address)`.
+            mstore(0x00, 0xccf790a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,bool)`.
+            mstore(0x00, 0xc4643e20)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,uint256)`.
+            mstore(0x00, 0x386ff5f4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,uint256,string)`.
+            mstore(0x00, 0x0aa6cfad)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,address)`.
+            mstore(0x00, 0x19fd4956)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,bool)`.
+            mstore(0x00, 0x50ad461d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,uint256)`.
+            mstore(0x00, 0x80e6a20b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,bool,string,string)`.
+            mstore(0x00, 0x475c5c33)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,address)`.
+            mstore(0x00, 0x478d1c62)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,bool)`.
+            mstore(0x00, 0xa1bcc9b3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,uint256)`.
+            mstore(0x00, 0x100f650e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,address,string)`.
+            mstore(0x00, 0x1da986ea)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,address)`.
+            mstore(0x00, 0xa31bfdcc)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,bool)`.
+            mstore(0x00, 0x3bf5e537)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,uint256)`.
+            mstore(0x00, 0x22f6b999)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,bool,string)`.
+            mstore(0x00, 0xc5ad85f9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,address)`.
+            mstore(0x00, 0x20e3984d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,bool)`.
+            mstore(0x00, 0x66f1bc67)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,uint256)`.
+            mstore(0x00, 0x34f0e636)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,uint256,string)`.
+            mstore(0x00, 0x4a28c017)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,address)`.
+            mstore(0x00, 0x5c430d47)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,bool)`.
+            mstore(0x00, 0xcf18105c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,uint256)`.
+            mstore(0x00, 0xbf01f891)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,uint256,string,string)`.
+            mstore(0x00, 0x88a8c406)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,address)`.
+            mstore(0x00, 0x0d36fa20)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,bool)`.
+            mstore(0x00, 0x0df12b76)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,uint256)`.
+            mstore(0x00, 0x457fe3cf)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,address,string)`.
+            mstore(0x00, 0xf7e36245)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,address)`.
+            mstore(0x00, 0x205871c2)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,bool)`.
+            mstore(0x00, 0x5f1d5c9f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,uint256)`.
+            mstore(0x00, 0x515e38b6)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,bool,string)`.
+            mstore(0x00, 0xbc0b61fe)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,address)`.
+            mstore(0x00, 0x63183678)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,bool)`.
+            mstore(0x00, 0x0ef7e050)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,uint256)`.
+            mstore(0x00, 0x1dc8e1b8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,uint256,string)`.
+            mstore(0x00, 0x448830a8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,address)`.
+            mstore(0x00, 0xa04e2f87)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,bool)`.
+            mstore(0x00, 0x35a5071f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,uint256)`.
+            mstore(0x00, 0x159f8927)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(address,string,string,string)`.
+            mstore(0x00, 0x5d02c50b)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,address)`.
+            mstore(0x00, 0x1d14d001)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,bool)`.
+            mstore(0x00, 0x46600be0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,uint256)`.
+            mstore(0x00, 0x0c66d1be)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,address,string)`.
+            mstore(0x00, 0xd812a167)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,address)`.
+            mstore(0x00, 0x1c41a336)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,bool)`.
+            mstore(0x00, 0x6a9c478b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,uint256)`.
+            mstore(0x00, 0x07831502)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,bool,string)`.
+            mstore(0x00, 0x4a66cb34)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,address)`.
+            mstore(0x00, 0x136b05dd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,bool)`.
+            mstore(0x00, 0xd6019f1c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,uint256)`.
+            mstore(0x00, 0x7bf181a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,uint256,string)`.
+            mstore(0x00, 0x51f09ff8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,address)`.
+            mstore(0x00, 0x6f7c603e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,bool)`.
+            mstore(0x00, 0xe2bfd60b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,uint256)`.
+            mstore(0x00, 0xc21f64c7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,address,string,string)`.
+            mstore(0x00, 0xa73c1db6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,address)`.
+            mstore(0x00, 0xf4880ea4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,bool)`.
+            mstore(0x00, 0xc0a302d8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,uint256)`.
+            mstore(0x00, 0x4c123d57)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,address,string)`.
+            mstore(0x00, 0xa0a47963)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,address)`.
+            mstore(0x00, 0x8c329b1a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,bool)`.
+            mstore(0x00, 0x3b2a5ce0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,uint256)`.
+            mstore(0x00, 0x6d7045c1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,bool,string)`.
+            mstore(0x00, 0x2ae408d4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,address)`.
+            mstore(0x00, 0x54a7a9a0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,bool)`.
+            mstore(0x00, 0x619e4d0e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,uint256)`.
+            mstore(0x00, 0x0bb00eab)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,uint256,string)`.
+            mstore(0x00, 0x7dd4d0e0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,address)`.
+            mstore(0x00, 0xf9ad2b89)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,bool)`.
+            mstore(0x00, 0xb857163a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,uint256)`.
+            mstore(0x00, 0xe3a9ca2f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,bool,string,string)`.
+            mstore(0x00, 0x6d1e8751)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,address)`.
+            mstore(0x00, 0x26f560a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,bool)`.
+            mstore(0x00, 0xb4c314ff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,uint256)`.
+            mstore(0x00, 0x1537dc87)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,address,string)`.
+            mstore(0x00, 0x1bb3b09a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,address)`.
+            mstore(0x00, 0x9acd3616)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,bool)`.
+            mstore(0x00, 0xceb5f4d7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,uint256)`.
+            mstore(0x00, 0x7f9bbca2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,bool,string)`.
+            mstore(0x00, 0x9143dbb1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,address)`.
+            mstore(0x00, 0x00dd87b9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,bool)`.
+            mstore(0x00, 0xbe984353)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,uint256)`.
+            mstore(0x00, 0x374bb4b2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,uint256,string)`.
+            mstore(0x00, 0x8e69fb5d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,address)`.
+            mstore(0x00, 0xfedd1fff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,bool)`.
+            mstore(0x00, 0xe5e70b2b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,uint256)`.
+            mstore(0x00, 0x6a1199e2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,uint256,string,string)`.
+            mstore(0x00, 0xf5bc2249)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,address)`.
+            mstore(0x00, 0x2b2b18dc)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,bool)`.
+            mstore(0x00, 0x6dd434ca)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,uint256)`.
+            mstore(0x00, 0xa5cada94)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,address,string)`.
+            mstore(0x00, 0x12d6c788)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,address)`.
+            mstore(0x00, 0x538e06ab)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,bool)`.
+            mstore(0x00, 0xdc5e935b)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,uint256)`.
+            mstore(0x00, 0x1606a393)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,bool,string)`.
+            mstore(0x00, 0x483d0416)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,address)`.
+            mstore(0x00, 0x1596a1ce)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,bool)`.
+            mstore(0x00, 0x6b0e5d53)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,uint256)`.
+            mstore(0x00, 0x28863fcb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,uint256,string)`.
+            mstore(0x00, 0x1ad96de6)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,address)`.
+            mstore(0x00, 0x97d394d8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,bool)`.
+            mstore(0x00, 0x1e4b87e5)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,uint256)`.
+            mstore(0x00, 0x7be0c3eb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(bool,string,string,string)`.
+            mstore(0x00, 0x1762e32a)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,address)`.
+            mstore(0x00, 0x2488b414)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,bool)`.
+            mstore(0x00, 0x091ffaf5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,uint256)`.
+            mstore(0x00, 0x736efbb6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,address,string)`.
+            mstore(0x00, 0x031c6f73)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,address)`.
+            mstore(0x00, 0xef72c513)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,bool)`.
+            mstore(0x00, 0xe351140f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,uint256)`.
+            mstore(0x00, 0x5abd992a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,bool,string)`.
+            mstore(0x00, 0x90fb06aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,address)`.
+            mstore(0x00, 0x15c127b5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,bool)`.
+            mstore(0x00, 0x5f743a7c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,uint256)`.
+            mstore(0x00, 0x0c9cd9c1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,uint256,string)`.
+            mstore(0x00, 0xddb06521)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,address)`.
+            mstore(0x00, 0x9cba8fff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,bool)`.
+            mstore(0x00, 0xcc32ab07)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,uint256)`.
+            mstore(0x00, 0x46826b5d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,address,string,string)`.
+            mstore(0x00, 0x3e128ca3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,address)`.
+            mstore(0x00, 0xa1ef4cbb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,bool)`.
+            mstore(0x00, 0x454d54a5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,uint256)`.
+            mstore(0x00, 0x078287f5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,address,string)`.
+            mstore(0x00, 0xade052c7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,address)`.
+            mstore(0x00, 0x69640b59)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,bool)`.
+            mstore(0x00, 0xb6f577a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,uint256)`.
+            mstore(0x00, 0x7464ce23)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,bool,string)`.
+            mstore(0x00, 0xdddb9561)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,address)`.
+            mstore(0x00, 0x88cb6041)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,bool)`.
+            mstore(0x00, 0x91a02e2a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,uint256)`.
+            mstore(0x00, 0xc6acc7a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,uint256,string)`.
+            mstore(0x00, 0xde03e774)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,address)`.
+            mstore(0x00, 0xef529018)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,bool)`.
+            mstore(0x00, 0xeb928d7f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,uint256)`.
+            mstore(0x00, 0x2c1d0746)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,bool,string,string)`.
+            mstore(0x00, 0x68c8b8bd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,address)`.
+            mstore(0x00, 0x56a5d1b1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,bool)`.
+            mstore(0x00, 0x15cac476)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,uint256)`.
+            mstore(0x00, 0x88f6e4b2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,address,string)`.
+            mstore(0x00, 0x6cde40b8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,address)`.
+            mstore(0x00, 0x9a816a83)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,bool)`.
+            mstore(0x00, 0xab085ae6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,uint256)`.
+            mstore(0x00, 0xeb7f6fd2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,bool,string)`.
+            mstore(0x00, 0xa5b4fc99)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,address)`.
+            mstore(0x00, 0xfa8185af)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,bool)`.
+            mstore(0x00, 0xc598d185)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,uint256)`.
+            mstore(0x00, 0x193fb800)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _sendLogPayload(0x1c, 0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,uint256,string)`.
+            mstore(0x00, 0x59cfcbe3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,address)`.
+            mstore(0x00, 0x42d21db7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,bool)`.
+            mstore(0x00, 0x7af6ab25)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,uint256)`.
+            mstore(0x00, 0x5da297eb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,uint256,string,string)`.
+            mstore(0x00, 0x27d8afd2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,address)`.
+            mstore(0x00, 0x6168ed61)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,bool)`.
+            mstore(0x00, 0x90c30a56)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,uint256)`.
+            mstore(0x00, 0xe8d3018d)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,address,string)`.
+            mstore(0x00, 0x9c3adfa1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,address)`.
+            mstore(0x00, 0xae2ec581)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,bool)`.
+            mstore(0x00, 0xba535d9c)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,uint256)`.
+            mstore(0x00, 0xcf009880)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,bool,string)`.
+            mstore(0x00, 0xd2d423cd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,address)`.
+            mstore(0x00, 0x3b2279b4)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,bool)`.
+            mstore(0x00, 0x691a8f74)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,uint256)`.
+            mstore(0x00, 0x82c25b74)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,uint256,string)`.
+            mstore(0x00, 0xb7b914ca)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,address)`.
+            mstore(0x00, 0xd583c602)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,bool)`.
+            mstore(0x00, 0xb3a6b6bd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,uint256)`.
+            mstore(0x00, 0xb028c9bd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(uint256,string,string,string)`.
+            mstore(0x00, 0x21ad0683)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,address)`.
+            mstore(0x00, 0xed8f28f6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,bool)`.
+            mstore(0x00, 0xb59dbd60)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,uint256)`.
+            mstore(0x00, 0x8ef3f399)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,address,string)`.
+            mstore(0x00, 0x800a1c67)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,address)`.
+            mstore(0x00, 0x223603bd)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,bool)`.
+            mstore(0x00, 0x79884c2b)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,uint256)`.
+            mstore(0x00, 0x3e9f866a)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,bool,string)`.
+            mstore(0x00, 0x0454c079)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,address)`.
+            mstore(0x00, 0x63fb8bc5)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,bool)`.
+            mstore(0x00, 0xfc4845f0)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,uint256)`.
+            mstore(0x00, 0xf8f51b1e)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,uint256,string)`.
+            mstore(0x00, 0x5a477632)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,address)`.
+            mstore(0x00, 0xaabc9a31)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,bool)`.
+            mstore(0x00, 0x5f15d28c)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,uint256)`.
+            mstore(0x00, 0x91d1112e)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,address,string,string)`.
+            mstore(0x00, 0x245986f2)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,address)`.
+            mstore(0x00, 0x33e9dd1d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,bool)`.
+            mstore(0x00, 0x958c28c6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,uint256)`.
+            mstore(0x00, 0x5d08bb05)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,address,string)`.
+            mstore(0x00, 0x2d8e33a4)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,address)`.
+            mstore(0x00, 0x7190a529)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,bool)`.
+            mstore(0x00, 0x895af8c5)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,uint256)`.
+            mstore(0x00, 0x8e3f78a9)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,bool,string)`.
+            mstore(0x00, 0x9d22d5dd)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,address)`.
+            mstore(0x00, 0x935e09bf)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,bool)`.
+            mstore(0x00, 0x8af7cf8a)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,uint256)`.
+            mstore(0x00, 0x64b5bb67)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,uint256,string)`.
+            mstore(0x00, 0x742d6ee7)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,address)`.
+            mstore(0x00, 0xe0625b29)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,bool)`.
+            mstore(0x00, 0x3f8a701d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,uint256)`.
+            mstore(0x00, 0x24f91465)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,bool,string,string)`.
+            mstore(0x00, 0xa826caeb)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,address)`.
+            mstore(0x00, 0x5ea2b7ae)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,bool)`.
+            mstore(0x00, 0x82112a42)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,uint256)`.
+            mstore(0x00, 0x4f04fdc6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,address,string)`.
+            mstore(0x00, 0x9ffb2f93)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,address)`.
+            mstore(0x00, 0xe0e95b98)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,bool)`.
+            mstore(0x00, 0x354c36d6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,uint256)`.
+            mstore(0x00, 0xe41b6f6f)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,bool,string)`.
+            mstore(0x00, 0xabf73a98)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,address)`.
+            mstore(0x00, 0xe21de278)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,bool)`.
+            mstore(0x00, 0x7626db92)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,uint256)`.
+            mstore(0x00, 0xa7a87853)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _sendLogPayload(0x1c, 0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,uint256,string)`.
+            mstore(0x00, 0x854b3496)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,address)`.
+            mstore(0x00, 0x7c4632a4)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,bool)`.
+            mstore(0x00, 0x7d24491d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,uint256)`.
+            mstore(0x00, 0xc67ea9d1)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,uint256,string,string)`.
+            mstore(0x00, 0x5ab84e1f)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,address)`.
+            mstore(0x00, 0x439c7bef)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,bool)`.
+            mstore(0x00, 0x5ccd4e37)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,uint256)`.
+            mstore(0x00, 0x7cc3c607)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,address,string)`.
+            mstore(0x00, 0xeb1bff80)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,address)`.
+            mstore(0x00, 0xc371c7db)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,bool)`.
+            mstore(0x00, 0x40785869)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,uint256)`.
+            mstore(0x00, 0xd6aefad2)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,bool,string)`.
+            mstore(0x00, 0x5e84b0ea)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,address)`.
+            mstore(0x00, 0x1023f7b2)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,bool)`.
+            mstore(0x00, 0xc3a8a654)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,uint256)`.
+            mstore(0x00, 0xf45d7d2c)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _sendLogPayload(0x1c, 0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,uint256,string)`.
+            mstore(0x00, 0x5d1a971a)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,address)`.
+            mstore(0x00, 0x6d572f44)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,bool)`.
+            mstore(0x00, 0x2c1754ed)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,uint256)`.
+            mstore(0x00, 0x8eafb02b)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _sendLogPayload(0x1c, 0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        bytes32 m11;
+        bytes32 m12;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            m11 := mload(0x160)
+            m12 := mload(0x180)
+            // Selector of `log(string,string,string,string)`.
+            mstore(0x00, 0xde68f20a)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, 0x140)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+            writeString(0x160, p3)
+        }
+        _sendLogPayload(0x1c, 0x184);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+            mstore(0x160, m11)
+            mstore(0x180, m12)
+        }
+    }
+}

--- a/lib/forge-std/test/StdChains.t.sol
+++ b/lib/forge-std/test/StdChains.t.sol
@@ -6,7 +6,7 @@ import "../src/Test.sol";
 contract StdChainsTest is Test {
     function testChainRpcInitialization() public {
         // RPCs specified in `foundry.toml` should be updated.
-        assertEq(getChain(1).rpcUrl, "https://mainnet.infura.io/v3/16a8be88795540b9b3903d8de0f7baa5");
+        assertEq(getChain(1).rpcUrl, "https://mainnet.infura.io/v3/b1d3925804e74152b316ca7da97060d3");
         assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
         assertEq(getChain("arbitrum_one_goerli").rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
 
@@ -18,11 +18,11 @@ contract StdChainsTest is Test {
 
         // Cannot override RPCs defined in `foundry.toml`
         vm.setEnv("MAINNET_RPC_URL", "myoverride2");
-        assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/16a8be88795540b9b3903d8de0f7baa5");
+        assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/b1d3925804e74152b316ca7da97060d3");
 
         // Other RPCs should remain unchanged.
         assertEq(getChain(31337).rpcUrl, "http://127.0.0.1:8545");
-        assertEq(getChain("sepolia").rpcUrl, "https://sepolia.infura.io/v3/f4a0bdad42674adab5fc0ac077ffab2b");
+        assertEq(getChain("sepolia").rpcUrl, "https://sepolia.infura.io/v3/b9794ad1ddf84dfb8c34d6bb5dca2001");
     }
 
     function testRpc(string memory rpcAlias) internal {
@@ -31,23 +31,23 @@ contract StdChainsTest is Test {
     }
 
     // Ensure we can connect to the default RPC URL for each chain.
-    function testRpcs() public {
-        testRpc("mainnet");
-        testRpc("goerli");
-        testRpc("sepolia");
-        testRpc("optimism");
-        testRpc("optimism_goerli");
-        testRpc("arbitrum_one");
-        testRpc("arbitrum_one_goerli");
-        testRpc("arbitrum_nova");
-        testRpc("polygon");
-        testRpc("polygon_mumbai");
-        testRpc("avalanche");
-        testRpc("avalanche_fuji");
-        testRpc("bnb_smart_chain");
-        testRpc("bnb_smart_chain_testnet");
-        testRpc("gnosis_chain");
-    }
+    // function testRpcs() public {
+    //     testRpc("mainnet");
+    //     testRpc("goerli");
+    //     testRpc("sepolia");
+    //     testRpc("optimism");
+    //     testRpc("optimism_goerli");
+    //     testRpc("arbitrum_one");
+    //     testRpc("arbitrum_one_goerli");
+    //     testRpc("arbitrum_nova");
+    //     testRpc("polygon");
+    //     testRpc("polygon_mumbai");
+    //     testRpc("avalanche");
+    //     testRpc("avalanche_fuji");
+    //     testRpc("bnb_smart_chain");
+    //     testRpc("bnb_smart_chain_testnet");
+    //     testRpc("gnosis_chain");
+    // }
 
     function testChainNoDefault() public {
         vm.expectRevert("StdChains getChain(string): Chain with alias \"does_not_exist\" not found.");

--- a/lib/forge-std/test/StdCheats.t.sol
+++ b/lib/forge-std/test/StdCheats.t.sol
@@ -57,7 +57,7 @@ contract StdCheatsTest is Test {
         test.bar(address(this));
     }
 
-    function testChangePrank() public {
+    function testChangePrankMsgSender() public {
         vm.startPrank(address(1337));
         test.bar(address(1337));
         changePrank(address(0xdead));
@@ -65,6 +65,23 @@ contract StdCheatsTest is Test {
         changePrank(address(1337));
         test.bar(address(1337));
         vm.stopPrank();
+    }
+
+    function testChangePrankMsgSenderAndTxOrigin() public {
+        vm.startPrank(address(1337), address(1338));
+        test.origin(address(1337), address(1338));
+        changePrank(address(0xdead), address(0xbeef));
+        test.origin(address(0xdead), address(0xbeef));
+        changePrank(address(1337), address(1338));
+        test.origin(address(1337), address(1338));
+        vm.stopPrank();
+    }
+
+    function testMakeAccountEquivalence() public {
+        Account memory account = makeAccount("1337");
+        (address addr, uint256 key) = makeAddrAndKey("1337");
+        assertEq(account.addr, addr);
+        assertEq(account.key, key);
     }
 
     function testMakeAddrEquivalence() public {
@@ -92,7 +109,7 @@ contract StdCheatsTest is Test {
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
-    function testDealTokenAdjustTS() public {
+    function testDealTokenAdjustTotalSupply() public {
         Bar barToken = new Bar();
         address bar = address(barToken);
         deal(bar, address(this), 10000e18, true);
@@ -103,9 +120,65 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(), 10000e18);
     }
 
+    function testDealERC1155Token() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        dealERC1155(bar, address(this), 0, 10000e18, false);
+        assertEq(barToken.balanceOf(address(this), 0), 10000e18);
+    }
+
+    function testDealERC1155TokenAdjustTotalSupply() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        dealERC1155(bar, address(this), 0, 10000e18, true);
+        assertEq(barToken.balanceOf(address(this), 0), 10000e18);
+        assertEq(barToken.totalSupply(0), 20000e18);
+        dealERC1155(bar, address(this), 0, 0, true);
+        assertEq(barToken.balanceOf(address(this), 0), 0);
+        assertEq(barToken.totalSupply(0), 10000e18);
+    }
+
+    function testDealERC721Token() public {
+        BarERC721 barToken = new BarERC721();
+        address bar = address(barToken);
+        dealERC721(bar, address(2), 1);
+        assertEq(barToken.balanceOf(address(2)), 1);
+        assertEq(barToken.balanceOf(address(1)), 0);
+        dealERC721(bar, address(1), 2);
+        assertEq(barToken.balanceOf(address(1)), 1);
+        assertEq(barToken.balanceOf(bar), 1);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
+    }
+
+    function testDestroyAccount() public {
+        // deploy something to destroy it
+        BarERC721 barToken = new BarERC721();
+        address bar = address(barToken);
+        vm.setNonce(bar, 10);
+        deal(bar, 100);
+
+        uint256 prevThisBalance = address(this).balance;
+        uint256 size;
+        assembly {
+            size := extcodesize(bar)
+        }
+
+        assertGt(size, 0);
+        assertEq(bar.balance, 100);
+        assertEq(vm.getNonce(bar), 10);
+
+        destroyAccount(bar, address(this));
+        assembly {
+            size := extcodesize(bar)
+        }
+        assertEq(address(this).balance, prevThisBalance + 100);
+        assertEq(vm.getNonce(bar), 0);
+        assertEq(size, 0);
+        assertEq(bar.balance, 0);
     }
 
     function testDeployCodeNoArgs() public {
@@ -295,6 +368,60 @@ contract StdCheatsTest is Test {
     }
 }
 
+contract StdCheatsMock is StdCheats {
+    // We deploy a mock version so we can properly test expected reverts.
+    function assumeNoBlacklisted_(address token, address addr) external {
+        return assumeNoBlacklisted(token, addr);
+    }
+}
+
+contract StdCheatsForkTest is Test {
+    address internal constant SHIB = 0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE;
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant USDC_BLACKLISTED_USER = 0x1E34A77868E19A6647b1f2F47B51ed72dEDE95DD;
+    address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+    address internal constant USDT_BLACKLISTED_USER = 0x8f8a8F4B54a2aAC7799d7bc81368aC27b852822A;
+
+    // We deploy a mock version so we can properly test the revert.
+    StdCheatsMock private stdCheats = new StdCheatsMock();
+
+    function setUp() public {
+        // All tests of the `assumeNoBlacklisted` method are fork tests using live contracts.
+        vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
+    }
+
+    function testCannotAssumeNoBlacklisted_EOA() external {
+        address eoa = vm.addr({privateKey: 1});
+        vm.expectRevert("StdCheats assumeNoBlacklisted(address,address): Token address is not a contract.");
+        assumeNoBlacklisted(eoa, address(0));
+    }
+
+    function testAssumeNoBlacklisted_TokenWithoutBlacklist(address addr) external {
+        assumeNoBlacklisted(SHIB, addr);
+        assertTrue(true);
+    }
+
+    function testAssumeNoBlacklisted_USDC() external {
+        vm.expectRevert();
+        stdCheats.assumeNoBlacklisted_(USDC, USDC_BLACKLISTED_USER);
+    }
+
+    function testAssumeNoBlacklisted_USDC(address addr) external {
+        assumeNoBlacklisted(USDC, addr);
+        assertFalse(USDCLike(USDC).isBlacklisted(addr));
+    }
+
+    function testAssumeNoBlacklisted_USDT() external {
+        vm.expectRevert();
+        stdCheats.assumeNoBlacklisted_(USDT, USDT_BLACKLISTED_USER);
+    }
+
+    function testAssumeNoBlacklisted_USDT(address addr) external {
+        assumeNoBlacklisted(USDT, addr);
+        assertFalse(USDTLike(USDT).isBlackListed(addr));
+    }
+}
+
 contract Bar {
     constructor() payable {
         /// `DEAL` STDCHEAT
@@ -302,7 +429,7 @@ contract Bar {
         balanceOf[address(this)] = totalSupply;
     }
 
-    /// `HOAX` STDCHEATS
+    /// `HOAX` and `CHANGEPRANK` STDCHEATS
     function bar(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
     }
@@ -320,6 +447,57 @@ contract Bar {
     /// `DEAL` STDCHEAT
     mapping(address => uint256) public balanceOf;
     uint256 public totalSupply;
+}
+
+contract BarERC1155 {
+    constructor() payable {
+        /// `DEALERC1155` STDCHEAT
+        _totalSupply[0] = 10000e18;
+        _balances[0][address(this)] = _totalSupply[0];
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual returns (uint256) {
+        return _balances[id][account];
+    }
+
+    function totalSupply(uint256 id) public view virtual returns (uint256) {
+        return _totalSupply[id];
+    }
+
+    /// `DEALERC1155` STDCHEAT
+    mapping(uint256 => mapping(address => uint256)) private _balances;
+    mapping(uint256 => uint256) private _totalSupply;
+}
+
+contract BarERC721 {
+    constructor() payable {
+        /// `DEALERC721` STDCHEAT
+        _owners[1] = address(1);
+        _balances[address(1)] = 1;
+        _owners[2] = address(this);
+        _owners[3] = address(this);
+        _balances[address(this)] = 2;
+    }
+
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        return _balances[owner];
+    }
+
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        address owner = _owners[tokenId];
+        return owner;
+    }
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+}
+
+interface USDCLike {
+    function isBlacklisted(address) external view returns (bool);
+}
+
+interface USDTLike {
+    function isBlackListed(address) external view returns (bool);
 }
 
 contract RevertingContract {

--- a/lib/forge-std/test/StdStyle.t.sol
+++ b/lib/forge-std/test/StdStyle.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../src/Test.sol";
+
+contract StdStyleTest is Test {
+    function testStyleColor() public pure {
+        console2.log(StdStyle.red("StdStyle.red String Test"));
+        console2.log(StdStyle.red(uint256(10e18)));
+        console2.log(StdStyle.red(int256(-10e18)));
+        console2.log(StdStyle.red(true));
+        console2.log(StdStyle.red(address(0)));
+        console2.log(StdStyle.redBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.redBytes32("StdStyle.redBytes32"));
+        console2.log(StdStyle.green("StdStyle.green String Test"));
+        console2.log(StdStyle.green(uint256(10e18)));
+        console2.log(StdStyle.green(int256(-10e18)));
+        console2.log(StdStyle.green(true));
+        console2.log(StdStyle.green(address(0)));
+        console2.log(StdStyle.greenBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.greenBytes32("StdStyle.greenBytes32"));
+        console2.log(StdStyle.yellow("StdStyle.yellow String Test"));
+        console2.log(StdStyle.yellow(uint256(10e18)));
+        console2.log(StdStyle.yellow(int256(-10e18)));
+        console2.log(StdStyle.yellow(true));
+        console2.log(StdStyle.yellow(address(0)));
+        console2.log(StdStyle.yellowBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.yellowBytes32("StdStyle.yellowBytes32"));
+        console2.log(StdStyle.blue("StdStyle.blue String Test"));
+        console2.log(StdStyle.blue(uint256(10e18)));
+        console2.log(StdStyle.blue(int256(-10e18)));
+        console2.log(StdStyle.blue(true));
+        console2.log(StdStyle.blue(address(0)));
+        console2.log(StdStyle.blueBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.blueBytes32("StdStyle.blueBytes32"));
+        console2.log(StdStyle.magenta("StdStyle.magenta String Test"));
+        console2.log(StdStyle.magenta(uint256(10e18)));
+        console2.log(StdStyle.magenta(int256(-10e18)));
+        console2.log(StdStyle.magenta(true));
+        console2.log(StdStyle.magenta(address(0)));
+        console2.log(StdStyle.magentaBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.magentaBytes32("StdStyle.magentaBytes32"));
+        console2.log(StdStyle.cyan("StdStyle.cyan String Test"));
+        console2.log(StdStyle.cyan(uint256(10e18)));
+        console2.log(StdStyle.cyan(int256(-10e18)));
+        console2.log(StdStyle.cyan(true));
+        console2.log(StdStyle.cyan(address(0)));
+        console2.log(StdStyle.cyanBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.cyanBytes32("StdStyle.cyanBytes32"));
+    }
+
+    function testStyleFontWeight() public pure {
+        console2.log(StdStyle.bold("StdStyle.bold String Test"));
+        console2.log(StdStyle.bold(uint256(10e18)));
+        console2.log(StdStyle.bold(int256(-10e18)));
+        console2.log(StdStyle.bold(address(0)));
+        console2.log(StdStyle.bold(true));
+        console2.log(StdStyle.boldBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.boldBytes32("StdStyle.boldBytes32"));
+        console2.log(StdStyle.dim("StdStyle.dim String Test"));
+        console2.log(StdStyle.dim(uint256(10e18)));
+        console2.log(StdStyle.dim(int256(-10e18)));
+        console2.log(StdStyle.dim(address(0)));
+        console2.log(StdStyle.dim(true));
+        console2.log(StdStyle.dimBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.dimBytes32("StdStyle.dimBytes32"));
+        console2.log(StdStyle.italic("StdStyle.italic String Test"));
+        console2.log(StdStyle.italic(uint256(10e18)));
+        console2.log(StdStyle.italic(int256(-10e18)));
+        console2.log(StdStyle.italic(address(0)));
+        console2.log(StdStyle.italic(true));
+        console2.log(StdStyle.italicBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.italicBytes32("StdStyle.italicBytes32"));
+        console2.log(StdStyle.underline("StdStyle.underline String Test"));
+        console2.log(StdStyle.underline(uint256(10e18)));
+        console2.log(StdStyle.underline(int256(-10e18)));
+        console2.log(StdStyle.underline(address(0)));
+        console2.log(StdStyle.underline(true));
+        console2.log(StdStyle.underlineBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.underlineBytes32("StdStyle.underlineBytes32"));
+        console2.log(StdStyle.inverse("StdStyle.inverse String Test"));
+        console2.log(StdStyle.inverse(uint256(10e18)));
+        console2.log(StdStyle.inverse(int256(-10e18)));
+        console2.log(StdStyle.inverse(address(0)));
+        console2.log(StdStyle.inverse(true));
+        console2.log(StdStyle.inverseBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.inverseBytes32("StdStyle.inverseBytes32"));
+    }
+
+    function testStyleCombined() public pure {
+        console2.log(StdStyle.red(StdStyle.bold("Red Bold String Test")));
+        console2.log(StdStyle.green(StdStyle.dim(uint256(10e18))));
+        console2.log(StdStyle.yellow(StdStyle.italic(int256(-10e18))));
+        console2.log(StdStyle.blue(StdStyle.underline(address(0))));
+        console2.log(StdStyle.magenta(StdStyle.inverse(true)));
+    }
+
+    function testStyleCustom() public pure {
+        console2.log(h1("Custom Style 1"));
+        console2.log(h2("Custom Style 2"));
+    }
+
+    function h1(string memory a) private pure returns (string memory) {
+        return StdStyle.cyan(StdStyle.inverse(StdStyle.bold(a)));
+    }
+
+    function h2(string memory a) private pure returns (string memory) {
+        return StdStyle.magenta(StdStyle.bold(StdStyle.underline(a)));
+    }
+}

--- a/lib/forge-std/test/StdUtils.t.sol
+++ b/lib/forge-std/test/StdUtils.t.sol
@@ -177,6 +177,21 @@ contract StdUtilsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                BOUND PRIVATE KEY
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testBoundPrivateKey() public {
+        assertEq(boundPrivateKey(0), 1);
+        assertEq(boundPrivateKey(1), 1);
+        assertEq(boundPrivateKey(300), 300);
+        assertEq(boundPrivateKey(9999), 9999);
+        assertEq(boundPrivateKey(SECP256K1_ORDER - 1), SECP256K1_ORDER - 1);
+        assertEq(boundPrivateKey(SECP256K1_ORDER), 1);
+        assertEq(boundPrivateKey(SECP256K1_ORDER + 1), 2);
+        assertEq(boundPrivateKey(UINT256_MAX), UINT256_MAX & SECP256K1_ORDER - 1); // x&y is equivalent to x-x%y
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                    BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/
 

--- a/test/Base.GSquared.t.sol
+++ b/test/Base.GSquared.t.sol
@@ -8,7 +8,7 @@ import "../contracts/GTranche.sol";
 import "../contracts/oracles/CurveOracle.sol";
 import "../contracts/pnl/PnLFixedRate.sol";
 import "../contracts/strategy/stop-loss/StopLossLogic.sol";
-import "../contracts/strategy/keeper/GStrategyGuard.sol";
+import {GStrategyGuard} from "../contracts/strategy/keeper/GStrategyGuard.sol";
 import "../contracts/strategy/keeper/GStrategyResolver.sol";
 import "../contracts/mocks/MockStrategy.sol";
 import "../contracts/strategy/ConvexStrategy.sol";

--- a/test/SnL.t.sol
+++ b/test/SnL.t.sol
@@ -173,8 +173,8 @@ contract SnLTest is BaseSetup {
 
         guard.harvest();
 
-        assertTrue(!fraxStrategy.canHarvest());
-        assertTrue(!guard.canHarvest());
+        assertFalse(fraxStrategy.canHarvest());
+        assertFalse(guard.canHarvest());
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Done:
1. Bump foundry version
2. Implement functions that are measuring profits against gas amount used to run harvest in $
    - Use CL to fetch ETH price in $
    - Use Curve virtual price to convert underlying vault assets to $
4. Tests