### PR TITLE
Guard against loss scenario

### DIFF
--- a/contracts/interfaces/IGStrategyGuard.sol
+++ b/contracts/interfaces/IGStrategyGuard.sol
@@ -25,4 +25,10 @@ interface IGStrategyGuard {
 
     /// @notice run strategy harvest
     function harvest() external;
+
+    /// @notice Check if any strategy with loss can be unlocked
+    function canUnlockLoss()
+        external
+        view
+        returns (bool canExec, bytes memory execPayload);
 }

--- a/contracts/interfaces/IGStrategyGuard.sol
+++ b/contracts/interfaces/IGStrategyGuard.sol
@@ -27,8 +27,14 @@ interface IGStrategyGuard {
     function harvest() external;
 
     /// @notice Check if any strategy with loss can be unlocked
-    function canUnlockLoss()
+    function canUnlockStrategy()
         external
         view
         returns (bool canExec, bytes memory execPayload);
+
+    /// @notice Set flag to unlock loss for strategy and it can be harvested
+    function unlockLoss(address strategy) external;
+
+    /// @notice Reset lossStartBlock to 0 for strategy
+    function resetLossStartBlock(address strategy) external;
 }

--- a/contracts/strategy/keeper/GStrategyGuard.sol
+++ b/contracts/strategy/keeper/GStrategyGuard.sol
@@ -438,9 +438,7 @@ contract GStrategyGuard is IGStrategyGuard {
             if (
                 !strategyCheck[strategy].canHarvestWithLoss &&
                 strategyCheck[strategy].lossStartBlock > 0
-            ) {
-                continue;
-            }
+            ) continue;
             if (
                 IStrategy(strategy).canHarvest() &&
                 _profitOrLossExceeded(IStrategy(strategy))

--- a/contracts/strategy/keeper/GStrategyGuard.sol
+++ b/contracts/strategy/keeper/GStrategyGuard.sol
@@ -5,7 +5,7 @@ import "../../interfaces/IStrategy.sol";
 import "../../interfaces/IGStrategyGuard.sol";
 import "../../interfaces/AggregatorV3Interface.sol";
 import "../../interfaces/ICurve3Pool.sol";
-import "../../GVault.sol";s
+import "../../GVault.sol";
 
 library GuardErrors {
     error NotOwner(); // 0x30cd7471
@@ -252,7 +252,7 @@ contract GStrategyGuard is IGStrategyGuard {
     /// @notice Check if any strategy with loss can be unlocked
     /// @return canExec true if a strategy can be unlocked
     /// @return execPayload payload to execute
-    function canUnlockLoss()
+    function canUnlockStrategy()
         external
         view
         returns (bool canExec, bytes memory execPayload)

--- a/contracts/strategy/keeper/GStrategyResolver.sol
+++ b/contracts/strategy/keeper/GStrategyResolver.sol
@@ -57,6 +57,17 @@ contract GStopLossResolver is Owned {
         }
     }
 
+    /// @notice returns function selector to gelato to unlock loss OR set lossStartBlock to 0 for the
+    /// first strategy that was locked with a loss
+    function taskCanUnlockLoss()
+        external
+        view
+        returns (bool canExec, bytes memory execPayload)
+    {
+        IGStrategyGuard executor = IGStrategyGuard(stopLossExecutor);
+        (canExec, execPayload) = executor.canUnlockLoss();
+    }
+
     /// @notice returns correct payload to gelato to trigger strategy
     /// stop loss on the GStopLossExecutor
     function taskTriggerStopLoss()

--- a/contracts/strategy/keeper/GStrategyResolver.sol
+++ b/contracts/strategy/keeper/GStrategyResolver.sol
@@ -65,7 +65,7 @@ contract GStopLossResolver is Owned {
         returns (bool canExec, bytes memory execPayload)
     {
         IGStrategyGuard executor = IGStrategyGuard(stopLossExecutor);
-        (canExec, execPayload) = executor.canUnlockLoss();
+        (canExec, execPayload) = executor.canUnlockStrategy();
     }
 
     /// @notice returns correct payload to gelato to trigger strategy

--- a/test/ConvexStrategyTest.t.sol
+++ b/test/ConvexStrategyTest.t.sol
@@ -32,6 +32,7 @@ contract ConvexStrategyTest is BaseSetup {
     using stdStorage for StdStorage;
 
     ConvexStrategy convexStrategy;
+    GStrategyGuard guard;
 
     function setUp() public virtual override {
         BaseSetup.setUp();
@@ -44,12 +45,14 @@ contract ConvexStrategyTest is BaseSetup {
             frax_lp
         );
         StopLossLogic snl = new StopLossLogic();
-
+        guard = new GStrategyGuard();
+        guard.setKeeper(BASED_ADDRESS);
         convexStrategy.setStopLossLogic(address(snl));
         snl.setStrategy(address(convexStrategy), 1e18, 400);
         convexStrategy.setKeeper(BASED_ADDRESS);
         gVault.removeStrategy(address(strategy));
         gVault.addStrategy(address(convexStrategy), 10000);
+        guard.addStrategy(address(strategy), 3600);
         vm.stopPrank();
     }
 

--- a/test/SnL.t.sol
+++ b/test/SnL.t.sol
@@ -226,7 +226,8 @@ contract SnLTest is BaseSetup {
         assertTrue(fraxStrategy.canHarvest());
         assertTrue(guard.canHarvest());
         guard.harvest();
-        assertTrue(!fraxStrategy.canHarvest());
+        // Frax can still be harvested because it was marked as locked because it has debt
+        assertTrue(fraxStrategy.canHarvest());
         // credit available for other strategies
         assertTrue(mimStrategy.canHarvest());
         assertTrue(musdStrategy.canHarvest());
@@ -471,7 +472,9 @@ contract SnLTest is BaseSetup {
             THREE_POOL_TOKEN.balanceOf(address(mimStrategy))
         );
 
-        (active, , , , primerTimestamp) = guard.strategyCheck(address(mimStrategy));
+        (active, , , , primerTimestamp) = guard.strategyCheck(
+            address(mimStrategy)
+        );
         assertEq(primerTimestamp, 0);
         assertTrue(!active);
 

--- a/test/SnL.t.sol
+++ b/test/SnL.t.sol
@@ -369,16 +369,16 @@ contract SnLTest is BaseSetup {
         uint64 primerTimestamp; // The time at which the health threshold was broken
 
         assertTrue(!fraxStrategy.canStopLoss());
-        (, , primerTimestamp) = guard.strategyCheck(address(fraxStrategy));
+        (, , , , primerTimestamp) = guard.strategyCheck(address(fraxStrategy));
         assertGt(primerTimestamp, 0);
         assertTrue(guard.canEndStopLoss());
 
         vm.startPrank(BASED_ADDRESS);
         guard.endStopLossPrimer();
 
-        (, , primerTimestamp) = guard.strategyCheck(address(fraxStrategy));
+        (, , , , primerTimestamp) = guard.strategyCheck(address(fraxStrategy));
         assertEq(primerTimestamp, 0);
-        (, , primerTimestamp) = guard.strategyCheck(address(mimStrategy));
+        (, , , , primerTimestamp) = guard.strategyCheck(address(mimStrategy));
         assertGt(primerTimestamp, 0);
         assertTrue(guard.canEndStopLoss());
         vm.stopPrank();
@@ -443,7 +443,7 @@ contract SnLTest is BaseSetup {
         );
         uint64 primerTimestamp;
         bool active;
-        (active, , primerTimestamp) = guard.strategyCheck(
+        (active, , , , primerTimestamp) = guard.strategyCheck(
             address(fraxStrategy)
         );
         assertEq(primerTimestamp, 0);
@@ -471,7 +471,7 @@ contract SnLTest is BaseSetup {
             THREE_POOL_TOKEN.balanceOf(address(mimStrategy))
         );
 
-        (active, , primerTimestamp) = guard.strategyCheck(address(mimStrategy));
+        (active, , , , primerTimestamp) = guard.strategyCheck(address(mimStrategy));
         assertEq(primerTimestamp, 0);
         assertTrue(!active);
 

--- a/test/SnL.t.sol
+++ b/test/SnL.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "./Base.GSquared.t.sol";
 import "../contracts/solmate/src/utils/SafeTransferLib.sol";
+import {GuardErrors} from "../contracts/strategy/keeper/GStrategyGuard.sol";
 
 contract SnLTest is BaseSetup {
     uint256 constant MIN_REPORT_DELAY = 172801;
@@ -114,6 +115,32 @@ contract SnLTest is BaseSetup {
         vm.label(address(fraxStrategy), "Frax Strategy");
         vm.label(address(musdStrategy), "mUSD Strategy");
         vm.label(address(mimStrategy), "mim Strategy");
+    }
+
+    function testGuardSetDebtThreshold() public {
+        uint256 initialThreshold = guard.debtThreshold();
+        vm.prank(BASED_ADDRESS);
+        guard.setDebtThreshold(1000);
+        assertEq(guard.debtThreshold(), 1000);
+        assertTrue(initialThreshold != guard.debtThreshold());
+    }
+
+    function testGuardSetDebtThresholdNotOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(GuardErrors.NotOwner.selector));
+        guard.setDebtThreshold(1000);
+    }
+
+    function testGuardSetGasThreshold() public {
+        uint256 initialThreshold = guard.gasThreshold();
+        vm.prank(BASED_ADDRESS);
+        guard.setGasThreshold(1000);
+        assertEq(guard.gasThreshold(), 1000);
+        assertTrue(initialThreshold != guard.gasThreshold());
+    }
+
+    function testGuardSetGasThresholdNotOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(GuardErrors.NotOwner.selector));
+        guard.setGasThreshold(1000);
     }
 
     // GIVEN a convex strategy not added to the stop loss logic


### PR DESCRIPTION
## Done:
Guard flow:
- In case of loss, strategy will be locked for 25 blocks
- Gelato job will be checking if loss is permanent for each of those 25 blocks and by the end of block 25 it will unlock strategy to be harvested with loss
- If loss to go before block 25, strategy will be unlocked as well