### PR TITLE
[fix] - fixing convex strategy rewards selling

### DIFF
--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -640,12 +640,12 @@ contract ConvexStrategy {
         }
 
         uint256 crvValue;
-        if (crv > MIN_REWARD_SELL_AMOUNT) {
+        if (crv > MIN_REWARD_SELL_AMOUNT && crvEthPool != address(0)) {
             crvValue = getPriceCurve(crvEthPool, crv);
         }
 
         uint256 cvxValue;
-        if (cvx > MIN_REWARD_SELL_AMOUNT) {
+        if (cvx > MIN_REWARD_SELL_AMOUNT && cvxEthPool != address(0)) {
             cvxValue = getPriceCurve(cvxEthPool, cvx);
         }
 
@@ -671,7 +671,7 @@ contract ConvexStrategy {
         }
 
         uint256 cvx = ERC20(CVX).balanceOf(address(this));
-        if (cvx > MIN_REWARD_SELL_AMOUNT) {
+        if (cvx > MIN_REWARD_SELL_AMOUNT && cvxEthPool != address(0)) {
             wethAmount += ICurveRewards(cvxEthPool).exchange(
                 CRV_ETH_INDEX,
                 0,
@@ -682,7 +682,7 @@ contract ConvexStrategy {
         }
 
         uint256 crv = ERC20(CRV).balanceOf(address(this));
-        if (crv > MIN_REWARD_SELL_AMOUNT) {
+        if (crv > MIN_REWARD_SELL_AMOUNT && crvEthPool != address(0)) {
             wethAmount += ICurveRewards(crvEthPool).exchange(
                 CRV_ETH_INDEX,
                 0,

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -1169,6 +1169,12 @@ contract ConvexStrategy {
         return (meta_pool_vp * PERCENTAGE_DECIMAL_FACTOR) / three_pool_vp;
     }
 
+    /// @notice Claims rewards from the convex reward pool
+    function claimRewards() external {
+        if (msg.sender != owner) revert StrategyErrors.NotOwner();
+        Rewards(rewardContract).getReward();
+    }
+
     /// @notice sweep unwanted tokens from the contract
     /// @param _recipient of the token
     /// @param _token address of

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -552,7 +552,7 @@ contract ConvexStrategy {
 
     /// @notice Claim and sell off all reward tokens for underlying asset
     function sellAllRewards() internal returns (uint256) {
-        // Early revert in case of emergency mode
+        // Early return in case of emergency mode
         if (emergencyMode) return 0;
         Rewards(rewardContract).getReward();
         return _sellRewards();

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -559,6 +559,8 @@ contract ConvexStrategy {
     }
 
     /// @notice Return combined value of all reward tokens in underlying asset
+    /// @dev Note that this doesn't include rewards that were already claimed. This might delay selling of rewards
+    /// @dev until next rewards are claimed if previous rewards are claimed.
     function rewards() public view returns (uint256) {
         return _claimableRewards() + _additionalRewardTokens();
     }
@@ -674,7 +676,6 @@ contract ConvexStrategy {
     function _sellRewards() internal returns (uint256) {
         uint256 wethAmount = ERC20(WETH).balanceOf(address(this));
         uint256 _numberOfRewards = numberOfRewards;
-
         if (_numberOfRewards > 0) {
             wethAmount += _sellAdditionalRewards(_numberOfRewards);
         }
@@ -820,7 +821,6 @@ contract ConvexStrategy {
             uint256 balance,
             uint256 _rewards
         ) = _estimatedTotalAssets(true);
-
         if (_rewards > MIN_REWARD_SELL_AMOUNT) balance = sellAllRewards();
         if (_excessDebt > assets) {
             // if we have more excess debt, this is an edge case and we shouldn't do any harvest at this point
@@ -979,7 +979,6 @@ contract ConvexStrategy {
 
         uint256 balance;
         bool emergency;
-
         // separate logic for emergency mode which needs implementation
         if (emergencyMode) {
             divestAll(false);

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -232,8 +232,8 @@ contract ConvexStrategy {
     address internal newRewardContract;
 
     // Additional reward tokens provided by CRV
-    address[MAX_REWARDS] public rewardTokens;
-    uint256 numberOfRewards;
+    address[] public rewardTokens;
+    uint256 public numberOfRewards;
 
     // Admin variables
     address public owner; // contract owner
@@ -416,6 +416,7 @@ contract ConvexStrategy {
         if (msg.sender != owner) revert StrategyErrors.NotOwner();
         if (_tokens.length > MAX_REWARDS)
             revert StrategyErrors.RewardsTokenMax();
+        // Revoke approval for all current reward tokens
         for (uint256 i; i < rewardTokens.length; i++) {
             ERC20(rewardTokens[i]).approve(UNI_V2, 0);
         }
@@ -423,7 +424,7 @@ contract ConvexStrategy {
         numberOfRewards = _tokens.length;
         for (uint256 i; i < _tokens.length; ++i) {
             address token = _tokens[i];
-            rewardTokens[i] = token;
+            rewardTokens.push(token);
             ERC20(token).approve(UNI_V2, type(uint256).max);
         }
         emit LogAdditionalRewards(_tokens);

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -944,7 +944,6 @@ contract ConvexStrategy {
 
         // separate logic for emergency mode which needs implementation
         if (emergencyMode) {
-            sellAllRewards();
             divestAll(false);
             emergency = true;
             debtRepayment = ASSET.balanceOf(address(this));
@@ -981,7 +980,7 @@ contract ConvexStrategy {
     ///     any gains/losses from this action to the vault
     function stopLoss() external returns (bool) {
         if (!keepers[msg.sender]) revert StrategyErrors.NotKeeper();
-        if (stopLossAttempts == 0) sellAllRewards();
+        if (stopLossAttempts == 0 && !emergencyMode) sellAllRewards();
         if (divestAll(true) == 0) {
             stopLossAttempts += 1;
             return false;

--- a/contracts/strategy/ConvexStrategy.sol
+++ b/contracts/strategy/ConvexStrategy.sol
@@ -1182,8 +1182,6 @@ contract ConvexStrategy {
         if (msg.sender != owner) revert StrategyErrors.NotOwner();
         if (address(ASSET) == _token) revert StrategyErrors.BaseAsset();
         if (address(lpToken) == _token) revert StrategyErrors.LpToken();
-        if (address(rewardContract) == _token)
-            revert StrategyErrors.ConvexToken();
         uint256 _amount = ERC20(_token).balanceOf(address(this));
         ERC20(_token).transfer(_recipient, _amount);
     }

--- a/test/Base.GSquared.t.sol
+++ b/test/Base.GSquared.t.sol
@@ -45,6 +45,8 @@ contract BaseSetup is Test {
         ERC20(address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48));
     ERC20 public constant USDT =
         ERC20(address(0xdAC17F958D2ee523a2206206994597C13D831ec7));
+    ERC20 public constant CURVE_TOKEN =
+        ERC20(address(0xD533a949740bb3306d119CC777fa900bA034cd52));
     address constant COFFEE_ADDRESS =
         address(0xc0ffEE4a95F15ff9973A17E563a8A8701D719890);
     address constant BASED_ADDRESS =

--- a/test/ConvexStrategyTest.t.sol
+++ b/test/ConvexStrategyTest.t.sol
@@ -1117,6 +1117,40 @@ contract ConvexStrategyTest is BaseSetup {
         vm.stopPrank();
     }
 
+    /// @notice Simple test to check allowance is set properly for additional rewards
+    function testSetAdditionalTokensAllowanceCheck() public {
+        // Make sure CRV starts with 0 allowance
+        assertEq(
+            CURVE_TOKEN.allowance(
+                address(convexStrategy),
+                address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D)
+            ),
+            0
+        );
+        tokens.push(address(CURVE_TOKEN));
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.setAdditionalRewards(tokens);
+        // Make sure Curve allowance for strategy is set as uint256 max value
+        assertEq(
+            CURVE_TOKEN.allowance(
+                address(convexStrategy),
+                address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D)
+            ),
+            type(uint256).max
+        );
+        // Now remove Curve from additional rewards and check that allowance is set to 0
+        tokens.pop();
+        tokens.push(address(USDC));
+        convexStrategy.setAdditionalRewards(tokens);
+        assertEq(
+            CURVE_TOKEN.allowance(
+                address(convexStrategy),
+                address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D)
+            ),
+            0
+        );
+    }
+
     // TODO: This test is omitted
     function test_strategy_should_claim_and_sell_rewards() private {
         depositIntoVault(alice, 1E24);

--- a/test/ConvexStrategyTest.t.sol
+++ b/test/ConvexStrategyTest.t.sol
@@ -58,6 +58,66 @@ contract ConvexStrategyTest is BaseSetup {
         vm.stopPrank();
     }
 
+    ////////////////////////////////////////////
+    ///////////// TEST SETTERS /////////////////
+    ////////////////////////////////////////////
+    /// @notice sets 3crv pool to arbitrary address
+    function testSet3crvPoolHappy() public {
+        assertEq(
+            convexStrategy.crv3pool(),
+            address(0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7)
+        );
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.set3CrvPool(musd_lp);
+        vm.stopPrank();
+        assertEq(convexStrategy.crv3pool(), musd_lp);
+    }
+
+    function testSet3crvPoolUnHappy() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(StrategyErrors.NotOwner.selector)
+        );
+        convexStrategy.set3CrvPool(musd_lp);
+    }
+
+    /// @notice sets crv eth pool to arbitrary address
+    function testSetCrvEthPoolHappy() public {
+        assertEq(
+            convexStrategy.crvEthPool(),
+            address(0x8301AE4fc9c624d1D396cbDAa1ed877821D7C511)
+        );
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.setCrvEthPool(musd_lp);
+        vm.stopPrank();
+        assertEq(convexStrategy.crvEthPool(), musd_lp);
+    }
+
+    function testSetCrvEthPoolUnHappy() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(StrategyErrors.NotOwner.selector)
+        );
+        convexStrategy.setCrvEthPool(musd_lp);
+    }
+
+    /// @notice sets cvx eth pool to arbitrary address
+    function testSetCvxEthPoolHappy() public {
+        assertEq(
+            convexStrategy.cvxEthPool(),
+            address(0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4)
+        );
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.setCvxEthPool(musd_lp);
+        vm.stopPrank();
+        assertEq(convexStrategy.cvxEthPool(), musd_lp);
+    }
+
+    function testSetCvxEthPoolUnHappy() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(StrategyErrors.NotOwner.selector)
+        );
+        convexStrategy.setCvxEthPool(musd_lp);
+    }
+
     function testStrategyHarvest(uint256 deposit) public {
         vm.assume(deposit > 1E20);
         vm.assume(deposit < 1E25);

--- a/test/ConvexStrategyTest.t.sol
+++ b/test/ConvexStrategyTest.t.sol
@@ -1057,6 +1057,27 @@ contract ConvexStrategyTest is BaseSetup {
         vm.stopPrank();
     }
 
+    function testClaimAndSweepRewards() public {
+        depositIntoVault(alice, 1E24);
+
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.runHarvest();
+        uint256 initialAssets = convexStrategy.estimatedTotalAssets();
+
+        prepareRewards(fraxConvexRewards);
+        assertGt(convexStrategy.estimatedTotalAssets(), initialAssets);
+
+        convexStrategy.claimRewards();
+        // Check that balance of curve token is non 0 after claim:
+        assertGt(CURVE_TOKEN.balanceOf(address(convexStrategy)), 0);
+        assertEq(CURVE_TOKEN.balanceOf(address(this)), 0);
+        // Sweep and check balance of curve token is 0 after sweep:
+        convexStrategy.sweep(address(this), address(CURVE_TOKEN));
+        assertEq(CURVE_TOKEN.balanceOf(address(convexStrategy)), 0);
+        assertGt(CURVE_TOKEN.balanceOf(address(this)), 0);
+        vm.stopPrank();
+    }
+
     // TODO: This test is omitted
     function test_strategy_should_claim_and_sell_rewards() private {
         depositIntoVault(alice, 1E24);

--- a/test/ConvexStrategyTest.t.sol
+++ b/test/ConvexStrategyTest.t.sol
@@ -9,7 +9,13 @@ contract ConvexStrategyTest is BaseSetup {
     uint256 constant MIN_REPORT_DELAY = 172801;
     uint256 constant MAX_REPORT_DELAY = 604801;
     uint256 constant LARGE_AMOUNT = 10**26;
+    address public constant CRV_ETH_POOL =
+        address(0x8301AE4fc9c624d1D396cbDAa1ed877821D7C511);
+    ERC20 public constant CVX =
+        ERC20(address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B));
 
+    address public CVX_ETH_POOL =
+        address(0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4);
     address frax_lp = address(0xd632f22692FaC7611d2AA1C0D552930D43CAEd3B);
     address frax = address(0x853d955aCEf822Db058eb8505911ED77F175b99e);
     address fraxConvexPool =
@@ -63,12 +69,23 @@ contract ConvexStrategyTest is BaseSetup {
     ////////////////////////////////////////////
     /// @notice sets 3crv pool to arbitrary address
     function testSet3crvPoolHappy() public {
+        // Check USDC allowance
+        assertEq(
+            USDC.allowance(address(convexStrategy), convexStrategy.crv3pool()),
+            type(uint256).max
+        );
         assertEq(
             convexStrategy.crv3pool(),
             address(0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7)
         );
         vm.startPrank(BASED_ADDRESS);
         convexStrategy.set3CrvPool(musd_lp);
+        assertEq(USDC.allowance(address(convexStrategy), THREE_POOL), 0);
+        // Check that musd allowance is set to max
+        assertEq(
+            USDC.allowance(address(convexStrategy), convexStrategy.crv3pool()),
+            type(uint256).max
+        );
         vm.stopPrank();
         assertEq(convexStrategy.crv3pool(), musd_lp);
     }
@@ -82,12 +99,31 @@ contract ConvexStrategyTest is BaseSetup {
 
     /// @notice sets crv eth pool to arbitrary address
     function testSetCrvEthPoolHappy() public {
+        // Check crv allowance
         assertEq(
-            convexStrategy.crvEthPool(),
-            address(0x8301AE4fc9c624d1D396cbDAa1ed877821D7C511)
+            CURVE_TOKEN.allowance(
+                address(convexStrategy),
+                convexStrategy.crvEthPool()
+            ),
+            type(uint256).max
         );
+        assertEq(convexStrategy.crvEthPool(), CRV_ETH_POOL);
         vm.startPrank(BASED_ADDRESS);
         convexStrategy.setCrvEthPool(musd_lp);
+
+        // Check curve allowance should be set to 0 now:
+        assertEq(
+            CURVE_TOKEN.allowance(address(convexStrategy), CRV_ETH_POOL),
+            0
+        );
+        // Check that musd allowance is set to max
+        assertEq(
+            CURVE_TOKEN.allowance(
+                address(convexStrategy),
+                convexStrategy.crvEthPool()
+            ),
+            type(uint256).max
+        );
         vm.stopPrank();
         assertEq(convexStrategy.crvEthPool(), musd_lp);
     }
@@ -101,12 +137,21 @@ contract ConvexStrategyTest is BaseSetup {
 
     /// @notice sets cvx eth pool to arbitrary address
     function testSetCvxEthPoolHappy() public {
+        // Check cvx allowance
         assertEq(
-            convexStrategy.cvxEthPool(),
-            address(0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4)
+            CVX.allowance(address(convexStrategy), convexStrategy.cvxEthPool()),
+            type(uint256).max
         );
+        assertEq(convexStrategy.cvxEthPool(), address(CVX_ETH_POOL));
         vm.startPrank(BASED_ADDRESS);
         convexStrategy.setCvxEthPool(musd_lp);
+        // Check cvx allowance should be set to 0 now:
+        assertEq(CVX.allowance(address(convexStrategy), CVX_ETH_POOL), 0);
+        // Check that musd allowance is set to max
+        assertEq(
+            CVX.allowance(address(convexStrategy), convexStrategy.cvxEthPool()),
+            type(uint256).max
+        );
         vm.stopPrank();
         assertEq(convexStrategy.cvxEthPool(), musd_lp);
     }
@@ -1114,6 +1159,25 @@ contract ConvexStrategyTest is BaseSetup {
         // Check that rewards are claimed but crv is not sold
         assertEq(convexStrategy.rewards(), 0);
         assertGt(CURVE_TOKEN.balanceOf(address(convexStrategy)), 0);
+        vm.stopPrank();
+    }
+
+    /// @notice Test for the case if crveth pool is borked and we set curve pool to a new one
+    function testSetCrvEthBorkedNewPoolSet() public {
+        depositIntoVault(alice, 1E24);
+        vm.startPrank(BASED_ADDRESS);
+        convexStrategy.runHarvest();
+        uint256 initialAssets = convexStrategy.estimatedTotalAssets();
+        convexStrategy.setCrvEthPool(address(0));
+        // Check that crv eth pool is now set to 0
+        assertEq(convexStrategy.crvEthPool(), address(0));
+        // Now set proper crveth pool and make sure rewards are sold
+        convexStrategy.setCrvEthPool(CRV_ETH_POOL);
+        prepareRewards(fraxConvexRewards);
+        assertGt(convexStrategy.rewards(), 0);
+        convexStrategy.runHarvest();
+        assertEq(CURVE_TOKEN.balanceOf(address(convexStrategy)), 0);
+        assertEq(convexStrategy.rewards(), 0);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Done:
1. Strategy doesn't sell rewards in case of `emergencyMode` is set to true
2. `setAdditionalRewards` is fixed and tested
3. All curve pools are non-constants now
4. More tests

By completing all from the above, we make sure that no matter the situation with Curve, we can keep strategies running and withdraw rewards without selling them